### PR TITLE
docs: add CONTRIBUTING.md and RELEASE_CHECKLIST.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ npm install
 prek install
 ```
 
+> **Note:** `prek` is a global tool (via [mise](https://mise.jdx.dev)) that runs lint and format checks. Install it with `mise install prek` if not already available.
+
 **Requirements:** Node.js >= 22, npm >= 10.
 
 Peer dependencies (`@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`) are in `devDependencies` — `npm install` pulls them automatically.
@@ -22,15 +24,15 @@ No build step. Pi loads `.ts` source directly (`tsconfig.json` has `noEmit: true
 
 ## Commands
 
-| Command                 | Purpose                                |
-| ----------------------- | -------------------------------------- |
-| `npm test`              | Run 132 unit tests via Vitest          |
-| `npm run test:watch`    | Run tests in watch mode                |
-| `npm run test:e2e`      | E2E smoke tests (needs `CLINE_API_KEY`) |
-| `npm run lint`          | Lint all files with oxlint             |
-| `npm run format`        | Auto-format all files with oxfmt       |
-| `npm run format:check`  | Check formatting without writing       |
-| `npm run typecheck`     | TypeScript strict mode check           |
+| Command                | Purpose                                 |
+| ---------------------- | --------------------------------------- |
+| `npm test`             | Run unit tests via Vitest               |
+| `npm run test:watch`   | Run tests in watch mode                 |
+| `npm run test:e2e`     | E2E smoke tests (needs `CLINE_API_KEY`) |
+| `npm run lint`         | Lint all files with oxlint              |
+| `npm run format`       | Auto-format all files with oxfmt        |
+| `npm run format:check` | Check formatting without writing        |
+| `npm run typecheck`    | TypeScript strict mode check            |
 
 Run `prek run --all-files` before pushing to run the full pre-commit suite.
 
@@ -38,7 +40,7 @@ Run `prek run --all-files` before pushing to run the full pre-commit suite.
 
 ### TypeScript
 
-- **Strict mode** is enabled — no `any`, no implicit `null`, no unsafe casts.
+- **Strict mode** is enabled — strict null checks, no implicit `any`, no unchecked indexed access, no unsafe casts.
 - All exports have JSDoc comments (`@param`, `@returns`, `@module` for modules).
 - Use `unknown` at I/O boundaries (JSON parse, API responses), guarded by type predicates (`isRecord`, `stringValue`) before use.
 - Prefer `readonly` arrays and `const` over `let`.
@@ -125,7 +127,7 @@ CLINE_API_KEY=your_key npm run test:e2e
 
 Follow [conventional commits](https://www.conventionalcommits.org/):
 
-```
+```text
 type(scope): description
 
 - bullet points for details

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,147 @@
+# Contributing to pi-clinepass-provider
+
+Thanks for your interest in contributing! This guide covers everything you need to get started.
+
+## Dev Setup
+
+```bash
+# Clone and install
+git clone https://github.com/jellydn/pi-clinepass-provider.git
+cd pi-clinepass-provider
+npm install
+
+# Install pre-commit hooks (enforces lint + format)
+prek install
+```
+
+**Requirements:** Node.js >= 22, npm >= 10.
+
+Peer dependencies (`@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`) are in `devDependencies` — `npm install` pulls them automatically.
+
+No build step. Pi loads `.ts` source directly (`tsconfig.json` has `noEmit: true`).
+
+## Commands
+
+| Command                 | Purpose                                |
+| ----------------------- | -------------------------------------- |
+| `npm test`              | Run 132 unit tests via Vitest          |
+| `npm run test:watch`    | Run tests in watch mode                |
+| `npm run test:e2e`      | E2E smoke tests (needs `CLINE_API_KEY`) |
+| `npm run lint`          | Lint all files with oxlint             |
+| `npm run format`        | Auto-format all files with oxfmt       |
+| `npm run format:check`  | Check formatting without writing       |
+| `npm run typecheck`     | TypeScript strict mode check           |
+
+Run `prek run --all-files` before pushing to run the full pre-commit suite.
+
+## Coding Conventions
+
+### TypeScript
+
+- **Strict mode** is enabled — no `any`, no implicit `null`, no unsafe casts.
+- All exports have JSDoc comments (`@param`, `@returns`, `@module` for modules).
+- Use `unknown` at I/O boundaries (JSON parse, API responses), guarded by type predicates (`isRecord`, `stringValue`) before use.
+- Prefer `readonly` arrays and `const` over `let`.
+
+### Architecture
+
+- **Dependency injection via options objects** — all I/O (file reading, fetching, env vars) is injectable through interfaces like `AuthKeyOptions`, `RemoteModelsOptions`, `WorkosRefreshOptions`. This makes every function testable without mocking globals.
+- **Shared abstractions** live in their canonical module:
+  - `src/auth.ts` — file-walking helpers (`walkAuthPaths`, `walkClineProviderSettings`)
+  - `src/workos.ts` — WorkOS protocol knowledge (token prefix, refresh, credential extraction)
+  - `src/env.ts` — shared constants and environment helpers
+  - `src/utils.ts` — pure type guards (`isRecord`, `stringValue`, `numberValue`, `booleanValue`)
+- **No circular dependencies** between modules.
+- **No feature logic leaking into shared paths** — each module owns a single concern.
+
+### Module Structure
+
+Each source module follows this pattern:
+
+```typescript
+/**
+ * Module description.
+ * @module clinepass-<name>
+ */
+
+// 1. Imports (node built-ins → external → internal)
+
+// 2. Constants and types
+
+// 3. Pure helpers (private)
+
+// 4. Exported functions
+```
+
+Files should stay under 300 lines. If a module grows beyond that, extract a sub-module into its own file.
+
+## Testing
+
+### Unit Tests
+
+- Tests live in `tests/unit/*.test.ts`, matched by Vitest's `tests/**/*.test.ts` glob.
+- **Every I/O surface is injectable** — tests use `AuthKeyOptions` / `RemoteModelsOptions` with mock `readFile`, `fileExists`, `fetch`, and `env` instead of touching the filesystem or network.
+- **Comprehensive unit tests** — run with `npm test`.
+
+Example:
+
+```typescript
+const key = resolveApiKey(undefined, {
+  env: { CLINE_API_KEY: "test-key" },
+  authPaths: [],
+});
+expect(key).toBe("test-key");
+```
+
+### Type Contract Tests
+
+`tests/type/contract.ts` is a compile-time assertion that our default export conforms to pi's `(api: ExtensionAPI) => Promise<void>` contract. If pi changes the contract in a breaking way, TypeScript will error here — catching the mismatch at build time rather than runtime.
+
+This file intentionally does NOT use the `.test.ts` suffix so Vitest skips it.
+
+### E2E Smoke Tests
+
+`tests/e2e/smoke.sh` tests against a live Cline API. Requires:
+
+- `CLINE_API_KEY` environment variable
+- `pi` installed globally
+
+Run manually before releases (CI can't hold private API keys for public repos):
+
+```bash
+CLINE_API_KEY=your_key npm run test:e2e
+```
+
+## Pull Request Process
+
+1. **Create a branch** from `main`: `feat/description`, `fix/description`, `docs/description`, `refactor/description`.
+2. **Make changes** following the coding conventions above.
+3. **Verify locally**: `npm test && npm run typecheck && npm run lint && npm run format:check`.
+4. **Push** and open a draft PR.
+5. **CI runs unit tests + typecheck + lint automatically** on every push.
+6. **Request review** when ready. Address feedback, then merge (squash preferred).
+
+### Commit Conventions
+
+Follow [conventional commits](https://www.conventionalcommits.org/):
+
+```
+type(scope): description
+
+- bullet points for details
+```
+
+Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`.
+
+Each commit should be atomic — one logical change per commit, staged explicitly (no `git add -A`).
+
+## Documentation
+
+- **ADR** — Architecture Decision Records in `doc/adr/`. Use for significant design decisions. Follow the existing format: Context → Decision Drivers → Options → Decision → Consequences.
+- **CONCERNS.md** — `.planning/codebase/CONCERNS.md` tracks remaining technical concerns and coverage gaps.
+- **CONTEXT.md** — domain glossary of ClinePass-specific terms.
+- **AGENTS.md** — agent-facing guide (architecture overview, commands, gotchas).
+
+## Questions?
+
+Open an issue or discussion on GitHub.

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,124 @@
+# Release Checklist
+
+Follow these steps when cutting a new release of pi-clinepass-provider.
+
+## 1. Pre-Release Verification
+
+Before bumping the version, verify everything is clean:
+
+```bash
+# Must be clean
+git status
+
+# All tests pass
+npm test
+
+# TypeScript strict mode
+npm run typecheck
+
+# Lint: 0 errors, 0 warnings
+npm run lint
+
+# Format: consistent
+npm run format:check
+
+# Pre-commit hooks
+prek run --all-files
+```
+
+## 2. E2E Smoke Tests
+
+Run manual end-to-end tests against a live Cline API. CI can't run these because
+`CLINE_API_KEY` cannot be stored in public repo secrets.
+
+```bash
+# Requires a valid ClinePass API key
+export CLINE_API_KEY=your_api_key_here
+
+# Run the smoke test script
+npm run test:e2e
+```
+
+### Manual Verification Checklist
+
+If the automated smoke test passes, additionally verify:
+
+- [ ] **Model discovery** — `pi --list-models clinepass` shows at least 8 models (dynamic discovery may add/remove models)
+- [ ] **Chat completions** — `pi --model clinepass/cline-pass/deepseek-v4-flash -p "Hello"` returns a coherent response
+- [ ] **Login flow (WorkOS OAuth)** — if you have `cline auth` credentials, `pi /login` → ClinePass detects them automatically
+- [ ] **Login flow (static API key)** — `pi /login` → ClinePass → paste key works without errors
+- [ ] **Error handling** — using an invalid API key produces a clear error message (not a stack trace)
+- [ ] **Model IDs match** — the model IDs in `src/models.ts` `MODELS` array match the live API `/models` endpoint (spot-check 2-3 models)
+
+## 3. Update Changelog
+
+Move entries from `[Unreleased]` to a new version section:
+
+```markdown
+## [X.Y.Z] — YYYY-MM-DD
+
+### Added / Changed / Fixed / Tests
+```
+
+Follow the existing format in `CHANGELOG.md`. Update the comparison links at the bottom.
+
+## 4. Bump Version & Tag
+
+```bash
+# Interactive (choose patch/minor/major)
+npm run release
+
+# Or explicit
+npm run release:patch    # 1.0.3 → 1.0.4
+npm run release:minor    # 1.0.3 → 1.1.0
+npm run release:major    # 1.0.3 → 2.0.0
+```
+
+This runs `bumpp` which:
+- Bumps version in `package.json`
+- Commits the change
+- Creates a git tag (`vX.Y.Z`)
+- Pushes the commit and tag
+
+## 5. Create GitHub Release
+
+After the tag is pushed:
+
+1. Go to [GitHub Releases](https://github.com/jellydn/pi-clinepass-provider/releases)
+2. Click **Draft a new release**
+3. Choose the new tag (`vX.Y.Z`)
+4. Title: `vX.Y.Z`
+5. Copy the relevant changelog section as the release notes
+6. Click **Publish release**
+
+## 6. Publish to npm
+
+```bash
+npm run pub
+```
+
+Verify the package is published:
+
+```bash
+npm view pi-clinepass-provider version
+```
+
+## 7. Post-Release Verification
+
+- [ ] `pi install npm:pi-clinepass-provider` installs the new version
+- [ ] `pi --list-models clinepass` shows the expected models
+- [ ] Quick chat test: `pi --model clinepass/cline-pass/deepseek-v4-flash -p "Hello"` works
+- [ ] GitHub release page shows the correct changelog
+
+## Emergency Rollback
+
+If a release needs to be rolled back:
+
+```bash
+# Unpublish from npm (within 72 hours of publish)
+npm unpublish pi-clinepass-provider@X.Y.Z
+
+# Delete the GitHub release and tag
+git tag -d vX.Y.Z
+git push origin :refs/tags/vX.Y.Z
+```

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -22,7 +22,7 @@ npm run lint
 # Format: consistent
 npm run format:check
 
-# Pre-commit hooks
+# Pre-commit hooks (via `prek` — global tool, install with `mise install prek`)
 prek run --all-files
 ```
 
@@ -43,7 +43,7 @@ npm run test:e2e
 
 If the automated smoke test passes, additionally verify:
 
-- [ ] **Model discovery** — `pi --list-models clinepass` shows at least 8 models (dynamic discovery may add/remove models)
+- [ ] **Model discovery** — `pi --list-models clinepass` shows the expected models (dynamic discovery may add/remove models)
 - [ ] **Chat completions** — `pi --model clinepass/cline-pass/deepseek-v4-flash -p "Hello"` returns a coherent response
 - [ ] **Login flow (WorkOS OAuth)** — if you have `cline auth` credentials, `pi /login` → ClinePass detects them automatically
 - [ ] **Login flow (static API key)** — `pi /login` → ClinePass → paste key works without errors
@@ -75,6 +75,7 @@ npm run release:major    # 1.0.3 → 2.0.0
 ```
 
 This runs `bumpp` which:
+
 - Bumps version in `package.json`
 - Commits the change
 - Creates a git tag (`vX.Y.Z`)
@@ -115,10 +116,12 @@ npm view pi-clinepass-provider version
 If a release needs to be rolled back:
 
 ```bash
-# Unpublish from npm (within 72 hours of publish)
-npm unpublish pi-clinepass-provider@X.Y.Z
+# Deprecate the package on npm (preferred for established releases)
+npm deprecate pi-clinepass-provider@X.Y.Z "deprecated due to rollback, use vX.Y.Z+1"
 
 # Delete the GitHub release and tag
 git tag -d vX.Y.Z
 git push origin :refs/tags/vX.Y.Z
 ```
+
+> **Note:** `npm unpublish` is only possible within 72 hours of publishing and requires the `--force` flag. For established releases, deprecation is the standard approach.


### PR DESCRIPTION
## What

Add two new documentation files to the repository:
- `CONTRIBUTING.md` — contributor guide covering dev setup, commands, coding conventions, module structure, testing strategy, PR process, and commit conventions.
- `RELEASE_CHECKLIST.md` — step-by-step release procedure from pre-release verification through publishing and rollback.

## Why

The project had no centralized contributor guidance or release procedure, making it difficult for new contributors to get started and for maintainers to cut releases consistently without missing steps.

## How

- Both documents follow the existing project conventions (conventional commits, JSDoc exports, strict TypeScript, dependency injection patterns).
- CONTRIBUTING.md captures conventions already in use (module structure from `src/`, testing patterns from `tests/`, prek hooks from `AGENTS.md`).
- RELEASE_CHECKLIST.md formalizes the workflow from AGENTS.md's `npm run release` + `npm run pub` commands into a complete checklist with manual smoke tests and rollback procedures.

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] No breaking changes (or breaking changes documented above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded contribution guidance with setup steps, development commands, coding conventions, testing expectations, and pull request workflow.
  * Added a release checklist with verification steps, manual smoke-test guidance, versioning and publishing instructions, and rollback procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->