### PR TITLE
fix: add thinking level maps to model configurations

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -28,6 +28,16 @@ export interface ModelConfig {
   cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
   contextWindow: number;
   maxTokens: number;
+  /**
+   * Maps pi thinking levels to provider-specific reasoning_effort values; null
+   * marks a level unsupported. The Cline client exposes reasoning effort as
+   * low/medium/high (plus "off" to disable reasoning) — it does not support
+   * "minimal" or "xhigh", so those are mapped to null unless a model's upstream
+   * provider offers an extra-high tier (e.g. z.ai "max", DeepSeek "max").
+   */
+  thinkingLevelMap?: Partial<
+    Record<"off" | "minimal" | "low" | "medium" | "high" | "xhigh", string | null>
+  >;
 }
 
 export const MODELS: readonly ModelConfig[] = [
@@ -39,6 +49,7 @@ export const MODELS: readonly ModelConfig[] = [
     cost: { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 },
     contextWindow: 200_000,
     maxTokens: 131_072,
+    thinkingLevelMap: { minimal: null, low: "low", medium: "medium", high: "high", xhigh: "xhigh" },
   },
   {
     id: "cline-pass/kimi-k2.7-code",
@@ -48,6 +59,7 @@ export const MODELS: readonly ModelConfig[] = [
     cost: { input: 0.95, output: 4.0, cacheRead: 0.19, cacheWrite: 0 },
     contextWindow: 262_144,
     maxTokens: 131_072,
+    thinkingLevelMap: { off: null },
   },
   {
     id: "cline-pass/kimi-k2.6",
@@ -57,6 +69,7 @@ export const MODELS: readonly ModelConfig[] = [
     cost: { input: 0.95, output: 4.0, cacheRead: 0.16, cacheWrite: 0 },
     contextWindow: 262_144,
     maxTokens: 131_072,
+    thinkingLevelMap: { off: null },
   },
   {
     id: "cline-pass/deepseek-v4-pro",
@@ -66,6 +79,7 @@ export const MODELS: readonly ModelConfig[] = [
     cost: { input: 1.74, output: 3.48, cacheRead: 0.0145, cacheWrite: 0 },
     contextWindow: 1_000_000,
     maxTokens: 384_000,
+    thinkingLevelMap: { minimal: null, low: null, medium: null, high: "high", xhigh: "high" },
   },
   {
     id: "cline-pass/deepseek-v4-flash",
@@ -75,6 +89,7 @@ export const MODELS: readonly ModelConfig[] = [
     cost: { input: 0.14, output: 0.28, cacheRead: 0.0028, cacheWrite: 0 },
     contextWindow: 1_000_000,
     maxTokens: 384_000,
+    thinkingLevelMap: { minimal: null, low: null, medium: null, high: "high", xhigh: "high" },
   },
   {
     id: "cline-pass/mimo-v2.5",
@@ -84,6 +99,7 @@ export const MODELS: readonly ModelConfig[] = [
     cost: { input: 0.14, output: 0.28, cacheRead: 0.0028, cacheWrite: 0 },
     contextWindow: 262_144,
     maxTokens: 131_072,
+    thinkingLevelMap: { minimal: null, low: "low", medium: "medium", high: "high", xhigh: null },
   },
   {
     id: "cline-pass/mimo-v2.5-pro",
@@ -93,6 +109,7 @@ export const MODELS: readonly ModelConfig[] = [
     cost: { input: 1.74, output: 3.48, cacheRead: 0.0145, cacheWrite: 0 },
     contextWindow: 262_144,
     maxTokens: 131_072,
+    thinkingLevelMap: { minimal: null, low: "low", medium: "medium", high: "high", xhigh: null },
   },
   {
     id: "cline-pass/minimax-m3",
@@ -102,6 +119,7 @@ export const MODELS: readonly ModelConfig[] = [
     cost: { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0 },
     contextWindow: 1_048_576,
     maxTokens: 131_072,
+    thinkingLevelMap: { minimal: null, low: "low", medium: "medium", high: "high", xhigh: null },
   },
   {
     id: "cline-pass/qwen3.7-max",
@@ -111,6 +129,7 @@ export const MODELS: readonly ModelConfig[] = [
     cost: { input: 2.5, output: 7.5, cacheRead: 0.5, cacheWrite: 3.125 },
     contextWindow: 262_144,
     maxTokens: 131_072,
+    thinkingLevelMap: { minimal: null, low: "low", medium: "medium", high: "high", xhigh: null },
   },
   {
     id: "cline-pass/qwen3.7-plus",
@@ -121,6 +140,7 @@ export const MODELS: readonly ModelConfig[] = [
     cost: { input: 0.4, output: 1.6, cacheRead: 0.04, cacheWrite: 0.5 },
     contextWindow: 1_048_576,
     maxTokens: 131_072,
+    thinkingLevelMap: { minimal: null, low: "low", medium: "medium", high: "high", xhigh: null },
   },
 ];
 
@@ -180,7 +200,16 @@ function parseRemoteModel(raw: RawModelEntry, fallback?: ModelConfig): ModelConf
     cacheWrite: fallback?.cost.cacheWrite ?? 0,
   };
 
-  return { id, name, reasoning, input: ["text"], cost, contextWindow, maxTokens };
+  return {
+    id,
+    name,
+    reasoning,
+    input: ["text"],
+    cost,
+    contextWindow,
+    maxTokens,
+    thinkingLevelMap: fallback?.thinkingLevelMap,
+  };
 }
 
 /**

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -36,6 +36,83 @@ describe("MODELS", () => {
       expect(m.input).toEqual(["text"]);
     }
   });
+
+  it("every model declares a thinkingLevelMap", () => {
+    // All 10 ClinePass models should have an explicit thinkingLevelMap so the
+    // supported thinking levels are self-documenting and consistent.
+    for (const m of MODELS) {
+      expect(m.thinkingLevelMap).toBeDefined();
+    }
+  });
+
+  it("thinkingLevelMap values are valid (string reasoning_effort, null, or omitted)", () => {
+    const validLevels = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+    for (const m of MODELS) {
+      const map = m.thinkingLevelMap!;
+      for (const level of validLevels) {
+        const value = map[level];
+        // A level is either mapped to a reasoning_effort string, explicitly
+        // unsupported (null), or omitted (undefined → uses the provider default).
+        expect(value === null || value === undefined || typeof value === "string").toBe(true);
+      }
+    }
+  });
+
+  it("models without an upstream xhigh tier restrict minimal and xhigh to null", () => {
+    // The Cline client only exposes reasoning effort as low/medium/high (plus
+    // "off"). It does not support "minimal" or "xhigh". Models whose upstream
+    // provider has no extra-high tier (e.g. z.ai "max", DeepSeek "max") must
+    // map both minimal and xhigh to null.
+    const withoutXhigh = [
+      "cline-pass/mimo-v2.5",
+      "cline-pass/mimo-v2.5-pro",
+      "cline-pass/minimax-m3",
+      "cline-pass/qwen3.7-max",
+      "cline-pass/qwen3.7-plus",
+    ];
+    for (const id of withoutXhigh) {
+      const model = MODELS.find((m) => m.id === id)!;
+      const map = model.thinkingLevelMap!;
+      expect(map.minimal).toBeNull();
+      expect(map.xhigh).toBeNull();
+      // low/medium/high are supported and send the standard Cline effort values.
+      expect(map.low).toBe("low");
+      expect(map.medium).toBe("medium");
+      expect(map.high).toBe("high");
+      // "off" is supported (not null) — reasoning can be disabled.
+      expect(map.off).not.toBeNull();
+    }
+  });
+
+  it("always-reasoning models (Kimi) mark off as null", () => {
+    const alwaysOn = ["cline-pass/kimi-k2.7-code", "cline-pass/kimi-k2.6"];
+    for (const id of alwaysOn) {
+      const model = MODELS.find((m) => m.id === id)!;
+      expect(model.thinkingLevelMap!.off).toBeNull();
+    }
+  });
+
+  it("DeepSeek V4 models only support high (and xhigh clamped to high)", () => {
+    for (const id of ["cline-pass/deepseek-v4-pro", "cline-pass/deepseek-v4-flash"]) {
+      const model = MODELS.find((m) => m.id === id)!;
+      const map = model.thinkingLevelMap!;
+      expect(map.minimal).toBeNull();
+      expect(map.low).toBeNull();
+      expect(map.medium).toBeNull();
+      expect(map.high).toBe("high");
+      expect(map.xhigh).toBe("high");
+    }
+  });
+
+  it("GLM-5.2 supports low/medium/high/xhigh (minimal unsupported)", () => {
+    const model = MODELS.find((m) => m.id === "cline-pass/glm-5.2")!;
+    const map = model.thinkingLevelMap!;
+    expect(map.minimal).toBeNull();
+    expect(map.low).toBe("low");
+    expect(map.medium).toBe("medium");
+    expect(map.high).toBe("high");
+    expect(map.xhigh).toBe("xhigh");
+  });
 });
 
 // ─── fetchRemoteModels ─────────────────────────────────────────────────────


### PR DESCRIPTION
  * Added support for model-specific “thinking level” settings, letting the app map each level to the best available reasoning option or mark it unsupported.
  * Remote model discovery now carries these settings forward, so newly detected models behave more consistently with curated ones.

* **Tests**
  * Expanded model coverage to verify thinking-level mappings across supported models and edge cases.