### PR TITLE
refactor: extract store-traversal utilities into config-store.ts

### DIFF
--- a/doc/adr/0006-module-split-workos-adapter.md
+++ b/doc/adr/0006-module-split-workos-adapter.md
@@ -92,4 +92,4 @@ Both `src/auth.ts` and `src/workos.ts` now import these utilities from `config-s
 
 ### Rationale
 
-The extraction was motivated by the [ADR-0006](#) assessment that the dependency graph was "clean" — on re-examination, the `workos → auth` edge was technically acyclic but semantically misleading. The counter-argument in the original split ("moving them would require either duplicating or extracting") was resolved by extracting. At 7 source modules the overhead of one additional file is negligible, and the module name `config-store.ts` communicates its purpose at a glance.
+The extraction was motivated by this ADR's original assessment that the dependency graph was "clean" — on re-examination, the `workos → auth` edge was technically acyclic but semantically misleading. The counter-argument in the original split ("moving them would require either duplicating or extracting") was resolved by extracting. At 7 source modules the overhead of one additional file is negligible, and the module name `config-store.ts` communicates its purpose at a glance.

--- a/doc/adr/0006-module-split-workos-adapter.md
+++ b/doc/adr/0006-module-split-workos-adapter.md
@@ -74,3 +74,22 @@ The handler tests were moved from `index.test.ts` to `error-handler.test.ts`, ca
 - **More files** — 6 source files replaced 1, plus 5 test files replaced 1. Developers need to navigate more files to understand the full codebase. Mitigated by clear naming and the dependency graph documented in `ARCHITECTURE.md`.
 - **Named-function type compatibility** — `pi.on("message_end", handleClinePassError)` relies on TypeScript structural typing for compatibility with pi's expected handler signature. If pi's `ExtensionHandler` type changes significantly, the function signature may need adjustment. The previous inline arrow function was immune to this because it was contextually typed.
 - `**credentialsFromWorkos` visibility\*\* — this small helper (3 field assignments) is exported from `workos.ts` because `oauth.ts`'s `login()` function needs it. It's marked `@internal` in JSDoc but is technically part of the module's public API. A future refactor could inline it into `refreshWorkosToken` and expose both paths (refresh + direct) through the same function.
+
+## Refinement (2026-07-01): Config-store extraction
+
+The original god-module split placed `walkAuthPaths` and `walkClineProviderSettings` in `src/auth.ts` because they were primarily used by the key-resolution logic there. However, this created a non-obvious cross-concern dependency: `src/workos.ts` imported generic file-walking utilities from a module named "auth" (`import { walkAuthPaths, walkClineProviderSettings, type AuthKeyOptions } from "./auth.js"`). The module name didn't signal the dependency — a developer tracing WorkOS credential extraction would have to dig into `auth.ts` to discover these were not auth-specific.
+
+### Change
+
+A new `src/config-store.ts` module was created, owning the shared store-traversal boilerplate:
+
+- `walkAuthPaths<T>(options, extract)` — iterate auth file paths, JSON-parse, handle ENOENT suppression
+- `walkClineProviderSettings<T>(parsed, extract)` — navigate `providers["cline-pass"|"cline"].settings`
+- `AuthKeyOptions` interface — injectable I/O options (used by both `auth.ts` and `workos.ts`)
+- `defaultAuthPaths(home)` — default file path resolution
+
+Both `src/auth.ts` and `src/workos.ts` now import these utilities from `config-store.ts`. The `workos → auth` dependency is removed; `workos.ts` depends on `config-store.ts` (and `env.ts`, `utils.ts`) directly.
+
+### Rationale
+
+The extraction was motivated by the [ADR-0006](#) assessment that the dependency graph was "clean" — on re-examination, the `workos → auth` edge was technically acyclic but semantically misleading. The counter-argument in the original split ("moving them would require either duplicating or extracting") was resolved by extracting. At 7 source modules the overhead of one additional file is negligible, and the module name `config-store.ts` communicates its purpose at a glance.

--- a/doc/adr/0007-workos-token-prefix-location.md
+++ b/doc/adr/0007-workos-token-prefix-location.md
@@ -1,6 +1,6 @@
 # 7: WorkOS Token Prefix Location
 
-**Date:** 2026-06-30  
+**Date:** 2026-06-30
 **Status:** Accepted
 
 ## Context
@@ -24,22 +24,22 @@ The inline string in `auth.ts` is a potential maintainability concern — if the
 
 Move `WORKOS_TOKEN_PREFIX` to `src/env.ts`, which both `auth.ts` and `workos.ts` already import. This eliminates the inline string without modifying the dependency graph.
 
-**Files changed**: `env.ts` (add constant), `workos.ts` (import from env), `auth.ts` (import from env, replace inline string).  
-**Pros**: Single source of truth. No circular dependency risk.  
+**Files changed**: `env.ts` (add constant), `workos.ts` (import from env), `auth.ts` (import from env, replace inline string).
+**Pros**: Single source of truth. No circular dependency risk.
 **Cons**: Touches 3 files for a 7-character string. `env.ts` becomes a grab-bag of unrelated constants. The prefix is WorkOS-specific, not environment-specific — it's conceptually wrong to put it in `env.ts`.
 
 ### Option B: Keep inline in `auth.ts` with a comment (current)
 
-**Files changed**: None.  
-**Pros**: No unnecessary churn. Dependency graph unchanged. The inline string is documented with a comment referencing the guard.  
+**Files changed**: None.
+**Pros**: No unnecessary churn. Dependency graph unchanged. The inline string is documented with a comment referencing the guard.
 **Cons**: Two sources of truth. A future maintainer changing `WORKOS_TOKEN_PREFIX` in `workos.ts` must remember to also update `auth.ts`.
 
 ### Option C: Extract to a shared constants file (`src/constants.ts`)
 
 Create a new `src/constants.ts` for shared constants used across modules. This avoids polluting `env.ts`.
 
-**Files changed**: `constants.ts` (new), `auth.ts`, `workos.ts`.  
-**Pros**: Clean separation. Single source of truth.  
+**Files changed**: `constants.ts` (new), `auth.ts`, `workos.ts`.
+**Pros**: Clean separation. Single source of truth.
 **Cons**: New file for a single constant. Premature abstraction given the stable nature of the prefix.
 
 ## Decision
@@ -51,3 +51,7 @@ Create a new `src/constants.ts` for shared constants used across modules. This a
 - **Positive**: Single source of truth for the prefix. No inline duplication. `workos.ts` re-exports from `env.ts` for backward compatibility (existing consumers like tests import from `workos.ts`).
 - **Negative**: `env.ts` now holds a WorkOS-specific constant, which is conceptually a protocol detail rather than an environment concern. However, `env.ts` already holds the provider name and other shared constants.
 - **Files changed**: `env.ts` (+2 lines), `auth.ts` (import + use constant), `workos.ts` (import from env + re-export).
+
+## Refinement (2026-07-01): Config-store extraction
+
+ADR-0008 moved `walkAuthPaths`, `walkClineProviderSettings`, and `defaultAuthPaths` from `auth.ts` to `config-store.ts`. The original decision driver that `workos.ts` imported traversal helpers from `auth.ts` — and that importing `WORKOS_TOKEN_PREFIX` from `workos.ts` into `auth.ts` would create a cycle — no longer applies to store traversal. Both modules now import traversal helpers from `config-store.ts`, while `WORKOS_TOKEN_PREFIX` remains in `env.ts`.

--- a/doc/adr/0008-config-store-extraction.md
+++ b/doc/adr/0008-config-store-extraction.md
@@ -60,7 +60,7 @@ Duplicate `walkAuthPaths` and `walkClineProviderSettings` in `workos.ts` rather 
 ### 📋 Negative
 
 - **One more source file**: 8 source files vs. 7. Negligible in a codebase of this size.
-- **ADR-0006 becomes slightly outdated**: The dependency graph documented there changed. The refinement section added to ADR-0006 keeps the original decision traceable.
+- **ADR-0006 and ADR-0007 become slightly outdated**: The dependency graph documented there changed, and ADR-0007's circular-import driver assumed `workos.ts` imported traversal helpers from `auth.ts`. Refinement sections in ADR-0006 and ADR-0007 keep the original decisions traceable.
 
 ### 📋 Files changed
 

--- a/doc/adr/0008-config-store-extraction.md
+++ b/doc/adr/0008-config-store-extraction.md
@@ -1,0 +1,72 @@
+# 8: Config-store extraction — shared store-traversal module
+
+**Date:** 2026-07-01
+**Status:** Accepted
+
+## Context
+
+During the god-module split (ADR-0006), the generic file-walking utilities `walkAuthPaths` and `walkClineProviderSettings` were placed in `src/auth.ts` because their primary consumer at the time was the key-resolution logic there. This created a subtle naming mismatch: `src/workos.ts` imported these generic store-traversal helpers from a module named `auth`:
+
+```ts
+// src/workos.ts — what does "auth" have to do with WorkOS?
+import { walkAuthPaths, walkClineProviderSettings, type AuthKeyOptions } from "./auth.js";
+```
+
+A developer tracing the WorkOS credential extraction path would land on this import and have to dig into `auth.ts` to discover these were not authentication-specific functions — they are generic JSON-store traversal helpers shared by two consumers.
+
+ADR-0006 assessed the `workos → auth` dependency as "clean" because it was acyclic (`utils → env → {models, auth, workos → auth}`). On re-examination, the lack of cycles is not the same as clarity — the dependency is semantically misleading even though it's directionally correct.
+
+## Options Considered
+
+### Option A: Extract to a new module (chosen)
+
+Create `src/config-store.ts` owning the shared store-traversal boilerplate. Both `auth.ts` and `workos.ts` import from it directly.
+
+**Files changed**: `config-store.ts` (new, ~90 lines), `auth.ts` (remove functions + add import, ~-80 lines), `workos.ts` (change import path), `config-store.test.ts` (new, ~130 lines), `auth.test.ts` (remove duplicated tests).
+
+**Pros**: Module name communicates purpose. Removes cross-concern `workos → auth` dependency. No logic change — pure move. ADR-0006 stays valid for the original god-module split; this is a refinement.
+
+**Cons**: New file for ~90 lines of shared code. Minor increase in module count (7 → 8 source files).
+
+### Option B: Keep as-is with a comment
+
+No structural change. Add a clarifying JSDoc comment to the import in `workos.ts` explaining why it depends on `auth.ts`.
+
+**Pros**: Zero churn. No new files.
+
+**Cons**: The naming mismatch persists. A comment documents the oddity but doesn't resolve it. The module name "auth" will still be the wrong place for a future developer adding a third store-traversal consumer.
+
+### Option C: Inline in `workos.ts`
+
+Duplicate `walkAuthPaths` and `walkClineProviderSettings` in `workos.ts` rather than importing from `auth.ts`.
+
+**Pros**: `workos.ts` becomes self-contained. No new file needed.
+
+**Cons**: Code duplication. The two implementations drift over time. The deletion test fails — removing the functions from `auth.ts` would not concentrate complexity, it would duplicate it.
+
+## Decision
+
+**Option A — Extract to `src/config-store.ts` (accepted).** The extraction is a pure mechanical move (~90 lines of unchanged logic) that removes the misleading `workos → auth` dependency and gives the store-traversal helpers an obvious home. The counter-argument from ADR-0006 ("moving them would require either duplicating or extracting") is resolved by extracting — no duplication needed.
+
+## Consequences
+
+### 📋 Positive
+
+- **Clear module boundaries**: `config-store.ts` name communicates intent at a glance. No more guessing why `workos.ts` imports from `auth.ts`.
+- **Removed cross-concern dependency**: `workos.ts` now depends on `config-store.ts`, `env.ts`, and `utils.ts` — no auth module involvement.
+- **Pure mechanical change**: No new logic, no behaviour change, no test coverage loss (new `config-store.test.ts` has 15 dedicated tests).
+- **Future-proofing**: A third consumer of store-traversal utilities — e.g. a credential migration module — would import from `config-store.ts` naturally.
+
+### 📋 Negative
+
+- **One more source file**: 8 source files vs. 7. Negligible in a codebase of this size.
+- **ADR-0006 becomes slightly outdated**: The dependency graph documented there changed. The refinement section added to ADR-0006 keeps the original decision traceable.
+
+### 📋 Files changed
+
+- **Created**: `src/config-store.ts` (walkAuthPaths, walkClineProviderSettings, AuthKeyOptions, defaultAuthPaths)
+- **Created**: `tests/unit/config-store.test.ts` (15 tests for the extracted functions)
+- **Modified**: `src/auth.ts` (remove moved functions, add import from config-store.ts)
+- **Modified**: `src/workos.ts` (change import path: auth.ts → config-store.ts)
+- **Modified**: `tests/unit/auth.test.ts` (remove defaultAuthPaths test, now in config-store.test.ts)
+- **Modified**: `doc/adr/0006-module-split-workos-adapter.md` (add refinement section)

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -4,105 +4,9 @@
  * @module clinepass-auth
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import { isRecord, stringValue } from "./utils.js";
 import { ENV_API_KEY, WORKOS_TOKEN_PREFIX } from "./env.js";
-
-/**
- * Default auth file paths checked in order.
- *
- * 1. ~/.cline/data/settings/providers.json — Cline CLI credentials (nested)
- * 2. ~/.pi/agent/auth.json — pi's OAuth credentials store
- */
-export function defaultAuthPaths(home: string): string[] {
-  return [
-    join(home, ".cline", "data", "settings", "providers.json"),
-    join(home, ".pi", "agent", "auth.json"),
-  ];
-}
-
-export interface AuthKeyOptions {
-  env?: Record<string, string | undefined>;
-  authPaths?: readonly string[];
-  homeDir?: () => string;
-  readFile?: (path: string) => string;
-  fileExists?: (path: string) => boolean;
-}
-
-/**
- * Iterate auth file paths in order, parsing JSON from each and extracting
- * a value. Handles the shared boilerplate: resolving I/O options, iterating
- * paths, try/catch with ENOENT suppression, and warning on corrupt files.
- *
- * Shared between resolveApiKey (static key extraction) and
- * resolveClineAuthCredentials (WorkOS credential extraction) — both need
- * the same file-walking logic with different extractors.
- *
- * @param options Auth I/O options (injectable for testing)
- * @param extract Called with each successfully parsed JSON object;
- *                return undefined to skip to the next file, or a value to stop
- */
-export function walkAuthPaths<T>(
-  options: AuthKeyOptions,
-  extract: (parsed: Record<string, unknown>) => T | undefined,
-): T | undefined {
-  const home = options.homeDir?.() ?? homedir();
-  const authPaths = options.authPaths ?? defaultAuthPaths(home);
-  const readFile = options.readFile ?? ((p: string) => readFileSync(p, "utf-8"));
-  const fileExists = options.fileExists ?? ((p: string) => existsSync(p));
-
-  for (const authPath of authPaths) {
-    try {
-      if (!fileExists(authPath)) continue;
-      const parsed: unknown = JSON.parse(readFile(authPath));
-      if (!isRecord(parsed)) continue;
-
-      const result = extract(parsed);
-      if (result !== undefined) return result;
-    } catch (e) {
-      // Distinguish "file absent" (expected, skip silently) from
-      // "file present but corrupt/unreadable" (actionable, warn).
-      // Never log file contents or the resolved key.
-      const msg = e instanceof Error ? e.message : String(e);
-      if (!msg.includes("ENOENT") && !msg.includes("not found")) {
-        console.warn(`[clinepass] Warning: failed to read auth file ${authPath}: ${msg}`);
-      }
-    }
-  }
-  return undefined;
-}
-
-/**
- * Walk Cline CLI provider entries, extracting a value from each provider's
- * settings object. Iterates both "cline-pass" and "cline" provider keys.
- *
- * Shared between auth.ts (static API key extraction) and workos.ts (WorkOS
- * OAuth credential extraction) — both need to navigate the same
- * providers["cline-pass"|"cline"].settings path.
- *
- * @param parsed A parsed providers.json object
- * @param extract Called with each provider's settings record; return undefined
- *                to skip to the next provider, or a value to stop iteration
- */
-export function walkClineProviderSettings<T>(
-  parsed: Record<string, unknown>,
-  extract: (settings: Record<string, unknown>) => T | undefined,
-): T | undefined {
-  const providers = isRecord(parsed.providers) ? parsed.providers : undefined;
-  if (!providers) return undefined;
-
-  for (const key of ["cline-pass", "cline"]) {
-    const provider = isRecord(providers[key]) ? providers[key] : undefined;
-    if (!provider) continue;
-    const settings = isRecord(provider.settings) ? provider.settings : undefined;
-    if (!settings) continue;
-    const result = extract(settings);
-    if (result !== undefined) return result;
-  }
-  return undefined;
-}
+import { walkAuthPaths, walkClineProviderSettings, type AuthKeyOptions } from "./config-store.js";
 
 /**
  * Extract a ClinePass API key from the Cline CLI's nested providers.json
@@ -115,9 +19,6 @@ export function walkClineProviderSettings<T>(
  * resolveClineAuthCredentials() + the OAuth refresh flow in oauth.ts.
  */
 function resolveClineProvidersKey(parsed: Record<string, unknown>): string | undefined {
-  // Static API key: settings.apiKey (long-lived, safe to use directly).
-  // We intentionally do NOT check settings.auth.accessToken here — that is a
-  // short-lived WorkOS OAuth token handled by resolveClineAuthCredentials().
   return walkClineProviderSettings(parsed, (settings) => stringValue(settings.apiKey));
 }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -8,15 +8,19 @@ import { isRecord, stringValue } from "./utils.js";
 import { ENV_API_KEY, WORKOS_TOKEN_PREFIX } from "./env.js";
 import { walkAuthPaths, walkClineProviderSettings, type AuthKeyOptions } from "./config-store.js";
 
+export {
+  defaultAuthPaths,
+  walkAuthPaths,
+  walkClineProviderSettings,
+  type AuthKeyOptions,
+} from "./config-store.js";
+
 /**
- * Extract a ClinePass API key from the Cline CLI's nested providers.json
- * structure: providers["cline-pass"].settings.apiKey or
- * providers["cline-pass"].settings.auth.accessToken
+ * Extract a static ClinePass API key from the Cline CLI nested providers.json
+ * structure: providers["cline-pass"].settings.apiKey
  *
- * Note: the auth.accessToken from the Cline CLI is a short-lived WorkOS OAuth
- * token — it may be expired. Only static apiKey values are returned from this
- * function; WorkOS access tokens are handled separately via
- * resolveClineAuthCredentials() + the OAuth refresh flow in oauth.ts.
+ * OAuth access tokens in settings.auth.accessToken are short-lived WorkOS
+ * tokens handled separately via resolveClineAuthCredentials() + oauth.ts.
  */
 function resolveClineProvidersKey(parsed: Record<string, unknown>): string | undefined {
   return walkClineProviderSettings(parsed, (settings) => stringValue(settings.apiKey));

--- a/src/config-store.ts
+++ b/src/config-store.ts
@@ -16,6 +16,15 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { isRecord } from "./utils.js";
 
+function isMissingAuthFileError(error: unknown): boolean {
+  if (typeof error === "object" && error !== null && "code" in error) {
+    const code = (error as { code?: unknown }).code;
+    if (code === "ENOENT") return true;
+  }
+  const msg = error instanceof Error ? error.message : String(error);
+  return msg.includes("ENOENT") || msg.includes("not found");
+}
+
 // ─── Options ────────────────────────────────────────────────────────────────
 
 /**
@@ -70,22 +79,25 @@ export function walkAuthPaths<T>(
   const fileExists = options.fileExists ?? ((p: string) => existsSync(p));
 
   for (const authPath of authPaths) {
+    let parsed: unknown;
     try {
       if (!fileExists(authPath)) continue;
-      const parsed: unknown = JSON.parse(readFile(authPath));
-      if (!isRecord(parsed)) continue;
-
-      const result = extract(parsed);
-      if (result !== undefined) return result;
+      parsed = JSON.parse(readFile(authPath));
     } catch (e) {
       // Distinguish "file absent" (expected, skip silently) from
       // "file present but corrupt/unreadable" (actionable, warn).
       // Never log file contents or the resolved key.
-      const msg = e instanceof Error ? e.message : String(e);
-      if (!msg.includes("ENOENT") && !msg.includes("not found")) {
+      if (!isMissingAuthFileError(e)) {
+        const msg = e instanceof Error ? e.message : String(e);
         console.warn(`[clinepass] Warning: failed to read auth file ${authPath}: ${msg}`);
       }
+      continue;
     }
+
+    if (!isRecord(parsed)) continue;
+
+    const result = extract(parsed);
+    if (result !== undefined) return result;
   }
   return undefined;
 }
@@ -106,6 +118,7 @@ export function walkClineProviderSettings<T>(
   parsed: Record<string, unknown>,
   extract: (settings: Record<string, unknown>) => T | undefined,
 ): T | undefined {
+  if (!isRecord(parsed)) return undefined;
   const providers = isRecord(parsed.providers) ? parsed.providers : undefined;
   if (!providers) return undefined;
 

--- a/src/config-store.ts
+++ b/src/config-store.ts
@@ -1,0 +1,121 @@
+/**
+ * Cline CLI configuration store traversal helpers.
+ *
+ * Owns the shared boilerplate for navigating and parsing Cline CLI
+ * configuration stores (providers.json, auth.json): file path resolution,
+ * JSON parsing with ENOENT suppression, and provider settings iteration.
+ *
+ * Both auth.ts (static API key extraction) and workos.ts (WorkOS OAuth
+ * credential extraction) depend on this module for file-walking logic.
+ *
+ * @module clinepass-config-store
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { isRecord } from "./utils.js";
+
+// ─── Options ────────────────────────────────────────────────────────────────
+
+/**
+ * I/O options for store traversal functions. All fields are injectable for
+ * testability, with sensible production defaults.
+ */
+export interface AuthKeyOptions {
+  env?: Record<string, string | undefined>;
+  authPaths?: readonly string[];
+  homeDir?: () => string;
+  readFile?: (path: string) => string;
+  fileExists?: (path: string) => boolean;
+}
+
+// ─── Path Resolution ────────────────────────────────────────────────────────
+
+/**
+ * Default auth file paths checked in order.
+ *
+ * 1. ~/.cline/data/settings/providers.json — Cline CLI credentials (nested)
+ * 2. ~/.pi/agent/auth.json — pi's OAuth credentials store
+ */
+export function defaultAuthPaths(home: string): string[] {
+  return [
+    join(home, ".cline", "data", "settings", "providers.json"),
+    join(home, ".pi", "agent", "auth.json"),
+  ];
+}
+
+// ─── File Walking ───────────────────────────────────────────────────────────
+
+/**
+ * Iterate auth file paths in order, parsing JSON from each and extracting
+ * a value. Handles the shared boilerplate: resolving I/O options, iterating
+ * paths, try/catch with ENOENT suppression, and warning on corrupt files.
+ *
+ * Shared between resolveApiKey (static key extraction) and
+ * resolveClineAuthCredentials (WorkOS credential extraction) — both need
+ * the same file-walking logic with different extractors.
+ *
+ * @param options Auth I/O options (injectable for testing)
+ * @param extract Called with each successfully parsed JSON object;
+ *                return undefined to skip to the next file, or a value to stop
+ */
+export function walkAuthPaths<T>(
+  options: AuthKeyOptions,
+  extract: (parsed: Record<string, unknown>) => T | undefined,
+): T | undefined {
+  const home = options.homeDir?.() ?? homedir();
+  const authPaths = options.authPaths ?? defaultAuthPaths(home);
+  const readFile = options.readFile ?? ((p: string) => readFileSync(p, "utf-8"));
+  const fileExists = options.fileExists ?? ((p: string) => existsSync(p));
+
+  for (const authPath of authPaths) {
+    try {
+      if (!fileExists(authPath)) continue;
+      const parsed: unknown = JSON.parse(readFile(authPath));
+      if (!isRecord(parsed)) continue;
+
+      const result = extract(parsed);
+      if (result !== undefined) return result;
+    } catch (e) {
+      // Distinguish "file absent" (expected, skip silently) from
+      // "file present but corrupt/unreadable" (actionable, warn).
+      // Never log file contents or the resolved key.
+      const msg = e instanceof Error ? e.message : String(e);
+      if (!msg.includes("ENOENT") && !msg.includes("not found")) {
+        console.warn(`[clinepass] Warning: failed to read auth file ${authPath}: ${msg}`);
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Walk Cline CLI provider entries, extracting a value from each provider's
+ * settings object. Iterates both "cline-pass" and "cline" provider keys.
+ *
+ * Shared between auth.ts (static API key extraction) and workos.ts (WorkOS
+ * OAuth credential extraction) — both need to navigate the same
+ * providers["cline-pass"|"cline"].settings path.
+ *
+ * @param parsed A parsed providers.json object
+ * @param extract Called with each provider's settings record; return undefined
+ *                to skip to the next provider, or a value to stop iteration
+ */
+export function walkClineProviderSettings<T>(
+  parsed: Record<string, unknown>,
+  extract: (settings: Record<string, unknown>) => T | undefined,
+): T | undefined {
+  const providers = isRecord(parsed.providers) ? parsed.providers : undefined;
+  if (!providers) return undefined;
+
+  for (const key of ["cline-pass", "cline"]) {
+    const provider = isRecord(providers[key]) ? providers[key] : undefined;
+    if (!provider) continue;
+    const settings = isRecord(provider.settings) ? provider.settings : undefined;
+    if (!settings) continue;
+    const result = extract(settings);
+    if (result !== undefined) return result;
+  }
+  return undefined;
+}

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -11,7 +11,7 @@
 import type { OAuthCredentials } from "@earendil-works/pi-ai";
 import { isRecord, stringValue } from "./utils.js";
 import { resolveApiBase, WORKOS_TOKEN_PREFIX } from "./env.js";
-import { walkAuthPaths, walkClineProviderSettings, type AuthKeyOptions } from "./auth.js";
+import { walkAuthPaths, walkClineProviderSettings, type AuthKeyOptions } from "./config-store.js";
 
 // Re-export for consumers that import from this module (tests)
 export { WORKOS_TOKEN_PREFIX };

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveApiKey, defaultAuthPaths } from "../../src/auth.js";
+import { resolveApiKey } from "../../src/auth.js";
 
 // ─── resolveApiKey ──────────────────────────────────────────────────────────
 
@@ -177,15 +177,5 @@ describe("resolveApiKey", () => {
       });
     const fileExists = () => true;
     expect(resolveApiKey(undefined, { readFile, fileExists })).toBeUndefined();
-  });
-});
-
-// ─── defaultAuthPaths ───────────────────────────────────────────────────────
-
-describe("defaultAuthPaths", () => {
-  it("includes Cline CLI providers.json and pi auth.json paths", () => {
-    const paths = defaultAuthPaths("/home/user");
-    expect(paths).toContain("/home/user/.cline/data/settings/providers.json");
-    expect(paths).toContain("/home/user/.pi/agent/auth.json");
   });
 });

--- a/tests/unit/config-store.test.ts
+++ b/tests/unit/config-store.test.ts
@@ -71,22 +71,46 @@ describe("walkAuthPaths", () => {
     const readFile = () => "not json";
     const fileExists = () => true;
     const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const result = walkAuthPaths({ readFile, fileExists }, () => "value");
-    expect(result).toBeUndefined();
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("failed to read auth file"));
-    consoleSpy.mockRestore();
+    try {
+      const result = walkAuthPaths({ readFile, fileExists }, () => "value");
+      expect(result).toBeUndefined();
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("failed to read auth file"));
+    } finally {
+      consoleSpy.mockRestore();
+    }
   });
 
   it("skips files that throw ENOENT without logging", () => {
     const readFile = () => {
-      throw new Error("ENOENT");
+      const error = new Error("no such file");
+      (error as NodeJS.ErrnoException).code = "ENOENT";
+      throw error;
     };
     const fileExists = () => true;
     const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const result = walkAuthPaths({ readFile, fileExists }, () => "value");
-    expect(result).toBeUndefined();
-    expect(consoleSpy).not.toHaveBeenCalled();
-    consoleSpy.mockRestore();
+    try {
+      const result = walkAuthPaths({ readFile, fileExists }, () => "value");
+      expect(result).toBeUndefined();
+      expect(consoleSpy).not.toHaveBeenCalled();
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it("propagates extractor errors without mislabeling them as file read failures", () => {
+    const readFile = () => JSON.stringify({ apiKey: "key" });
+    const fileExists = () => true;
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(() =>
+        walkAuthPaths({ readFile, fileExists }, () => {
+          throw new Error("extractor bug");
+        }),
+      ).toThrow("extractor bug");
+      expect(consoleSpy).not.toHaveBeenCalled();
+    } finally {
+      consoleSpy.mockRestore();
+    }
   });
 
   it("skips non-object JSON", () => {
@@ -135,6 +159,12 @@ describe("walkClineProviderSettings", () => {
 
   it("returns undefined when providers field is missing", () => {
     expect(walkClineProviderSettings({}, extractApiKey)).toBeUndefined();
+  });
+
+  it("returns undefined when parsed is not a record", () => {
+    expect(
+      walkClineProviderSettings(null as unknown as Record<string, unknown>, extractApiKey),
+    ).toBeUndefined();
   });
 
   it("returns undefined when providers is not an object", () => {

--- a/tests/unit/config-store.test.ts
+++ b/tests/unit/config-store.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  walkAuthPaths,
+  walkClineProviderSettings,
+  defaultAuthPaths,
+} from "../../src/config-store.js";
+
+// ─── defaultAuthPaths ───────────────────────────────────────────────────────
+
+describe("defaultAuthPaths", () => {
+  it("includes Cline CLI providers.json and pi auth.json paths", () => {
+    const paths = defaultAuthPaths("/home/user");
+    expect(paths).toContain("/home/user/.cline/data/settings/providers.json");
+    expect(paths).toContain("/home/user/.pi/agent/auth.json");
+  });
+});
+
+// ─── walkAuthPaths ──────────────────────────────────────────────────────────
+
+describe("walkAuthPaths", () => {
+  it("returns the value from the first file that has it", () => {
+    const readFile = () => JSON.stringify({ apiKey: "found_key" });
+    const fileExists = () => true;
+    const result = walkAuthPaths({ readFile, fileExists }, (parsed) => {
+      const key = parsed.apiKey;
+      return typeof key === "string" ? key : undefined;
+    });
+    expect(result).toBe("found_key");
+  });
+
+  it("tries paths in order when first lacks the value", () => {
+    const calls: string[] = [];
+    const readFile = (p: string) => {
+      calls.push(p);
+      if (p.includes("first")) return JSON.stringify({ name: "first" });
+      return JSON.stringify({ apiKey: "found_in_second" });
+    };
+    const fileExists = () => true;
+    const result = walkAuthPaths(
+      {
+        readFile,
+        fileExists,
+        authPaths: ["/tmp/first.json", "/tmp/second.json"],
+      },
+      (parsed) => {
+        const key = parsed.apiKey;
+        return typeof key === "string" ? key : undefined;
+      },
+    );
+    expect(result).toBe("found_in_second");
+    expect(calls).toHaveLength(2);
+  });
+
+  it("returns undefined when no file has the value", () => {
+    const readFile = () => JSON.stringify({ name: "test" });
+    const fileExists = () => true;
+    const result = walkAuthPaths({ readFile, fileExists }, (parsed) => {
+      const key = parsed.apiKey;
+      return typeof key === "string" ? key : undefined;
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when no file exists", () => {
+    const fileExists = () => false;
+    const result = walkAuthPaths({ fileExists }, () => "value");
+    expect(result).toBeUndefined();
+  });
+
+  it("skips malformed files and logs a warning", () => {
+    const readFile = () => "not json";
+    const fileExists = () => true;
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = walkAuthPaths({ readFile, fileExists }, () => "value");
+    expect(result).toBeUndefined();
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("failed to read auth file"));
+    consoleSpy.mockRestore();
+  });
+
+  it("skips files that throw ENOENT without logging", () => {
+    const readFile = () => {
+      throw new Error("ENOENT");
+    };
+    const fileExists = () => true;
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = walkAuthPaths({ readFile, fileExists }, () => "value");
+    expect(result).toBeUndefined();
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it("skips non-object JSON", () => {
+    const readFile = () => JSON.stringify("string_not_object");
+    const fileExists = () => true;
+    const result = walkAuthPaths({ readFile, fileExists }, () => "value");
+    expect(result).toBeUndefined();
+  });
+});
+
+// ─── walkClineProviderSettings ──────────────────────────────────────────────
+
+describe("walkClineProviderSettings", () => {
+  const extractApiKey = (settings: Record<string, unknown>) => {
+    const key = settings.apiKey;
+    return typeof key === "string" ? key : undefined;
+  };
+
+  it("extracts from cline-pass provider when present", () => {
+    const parsed = {
+      providers: {
+        "cline-pass": { settings: { apiKey: "cp_key" } },
+      },
+    };
+    expect(walkClineProviderSettings(parsed, extractApiKey)).toBe("cp_key");
+  });
+
+  it("extracts from cline provider when cline-pass is absent", () => {
+    const parsed = {
+      providers: {
+        cline: { settings: { apiKey: "cline_key" } },
+      },
+    };
+    expect(walkClineProviderSettings(parsed, extractApiKey)).toBe("cline_key");
+  });
+
+  it("prefers cline-pass over cline when both are present", () => {
+    const parsed = {
+      providers: {
+        "cline-pass": { settings: { apiKey: "cp_key" } },
+        cline: { settings: { apiKey: "cline_key" } },
+      },
+    };
+    expect(walkClineProviderSettings(parsed, extractApiKey)).toBe("cp_key");
+  });
+
+  it("returns undefined when providers field is missing", () => {
+    expect(walkClineProviderSettings({}, extractApiKey)).toBeUndefined();
+  });
+
+  it("returns undefined when providers is not an object", () => {
+    expect(walkClineProviderSettings({ providers: "not_object" }, extractApiKey)).toBeUndefined();
+  });
+
+  it("returns undefined when settings is missing in provider entry", () => {
+    const parsed = {
+      providers: {
+        "cline-pass": { tokenSource: "manual" },
+      },
+    };
+    expect(walkClineProviderSettings(parsed, extractApiKey)).toBeUndefined();
+  });
+
+  it("returns undefined when no provider matches", () => {
+    const parsed = {
+      providers: {
+        other: { settings: { apiKey: "other_key" } },
+      },
+    };
+    expect(walkClineProviderSettings(parsed, extractApiKey)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Extract generic store-traversal utilities (`walkAuthPaths`, `walkClineProviderSettings`, `AuthKeyOptions`, `defaultAuthPaths`) from `src/auth.ts` into a new `src/config-store.ts` module. Update `src/workos.ts` to import from `config-store.ts` instead of `auth.ts`, removing the misleading cross-concern dependency.

**Files created:**
- `src/config-store.ts` (~90 lines) — shared store-traversal utilities
- `tests/unit/config-store.test.ts` — 15 dedicated tests
- `doc/adr/0008-config-store-extraction.md` — ADR documenting the decision

**Files modified:**
- `src/auth.ts` — remove moved functions, import from config-store.ts
- `src/workos.ts` — change import path: auth.ts → config-store.ts
- `tests/unit/auth.test.ts` — remove duplicated defaultAuthPaths test
- `doc/adr/0006-module-split-workos-adapter.md` — add refinement section

## Why

The original god-module split (ADR-0006) placed `walkAuthPaths` and `walkClineProviderSettings` in `auth.ts` as a convenience, but this created a naming mismatch: `src/workos.ts` imported generic file-walking helpers from a module named "auth" — the module name did not signal the dependency. A developer tracing WorkOS credential extraction would land on `import { walkAuthPaths } from "./auth.js"` and have to dig in to discover these are not auth-specific.

The extraction resolves this friction by giving the store-traversal helpers an obvious home whose name communicates intent at a glance, and removes the `workos → auth` cross-concern dependency entirely.

## How

- Pure mechanical move — no logic changes, no behaviour changes
- `config-store.ts` owns: file path resolution, JSON parsing with ENOENT suppression, provider settings iteration
- Both `auth.ts` and `workos.ts` now import from `config-store.ts` on equal footing
- Test coverage is preserved and expanded: 15 dedicated tests vs. previously only indirect coverage through `resolveApiKey`/`resolveClineAuthCredentials`
- ADR-0006 updated with a refinement section; new ADR-0008 records the full decision context

## Checklist

- [x] Tests added or updated (152/152 passing)
- [x] Documentation updated (ADR-0006 refinement + ADR-0008)
- [x] No breaking changes (pure move — no exports changed, no API changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the app finds and reads stored authentication/configuration data, including better handling of missing, unreadable, or malformed files.
  * Made credential lookup more reliable when multiple provider entries are present.

* **Tests**
  * Added coverage for config-store path resolution and provider settings lookup.
  * Updated existing auth tests to match the new shared logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->