### PR TITLE
fix: map off thinking level to none

### DIFF
--- a/.changeset/fix-thinking-level-off-none.md
+++ b/.changeset/fix-thinking-level-off-none.md
@@ -1,0 +1,5 @@
+---
+"pi-clinepass-provider": patch
+---
+
+fix: map pi off thinking level to ClinePass reasoning.effort none

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Thinking level `off` mapping** — map pi's `off` thinking level to ClinePass `reasoning.effort: "none"` instead of `"off"`, fixing 400 errors on GLM 5.2 and other models when thinking is disabled ([#17](https://github.com/jellydn/pi-clinepass-provider/issues/17))
+
 ## [1.0.2] — 2026-06-30
 
 ### Added

--- a/src/models.ts
+++ b/src/models.ts
@@ -21,11 +21,11 @@ export type ThinkingLevelMap = Readonly<Record<ThinkingLevel, string | null>>;
 
 /**
  * Default thinking level map for remote models without a static fallback.
- * Assumes low/medium/high are supported and marks minimal/xhigh unsupported,
- * matching the Cline client's exposed levels.
+ * Assumes low/medium/high are supported and marks minimal/xhigh unsupported.
+ * "off" maps to "none" for the ClinePass API.
  */
 export const DEFAULT_THINKING_LEVEL_MAP: ThinkingLevelMap = {
-  off: "off",
+  off: "none",
   minimal: null,
   low: "low",
   medium: "medium",
@@ -83,7 +83,7 @@ export const MODELS: readonly ModelConfig[] = [
     contextWindow: 200_000,
     maxTokens: 131_072,
     thinkingLevelMap: {
-      off: "off",
+      off: "none",
       minimal: null,
       low: "low",
       medium: "medium",
@@ -134,7 +134,7 @@ export const MODELS: readonly ModelConfig[] = [
     contextWindow: 1_000_000,
     maxTokens: 384_000,
     thinkingLevelMap: {
-      off: "off",
+      off: "none",
       minimal: null,
       low: null,
       medium: null,
@@ -151,7 +151,7 @@ export const MODELS: readonly ModelConfig[] = [
     contextWindow: 1_000_000,
     maxTokens: 384_000,
     thinkingLevelMap: {
-      off: "off",
+      off: "none",
       minimal: null,
       low: null,
       medium: null,
@@ -168,7 +168,7 @@ export const MODELS: readonly ModelConfig[] = [
     contextWindow: 262_144,
     maxTokens: 131_072,
     thinkingLevelMap: {
-      off: "off",
+      off: "none",
       minimal: null,
       low: "low",
       medium: "medium",
@@ -185,7 +185,7 @@ export const MODELS: readonly ModelConfig[] = [
     contextWindow: 262_144,
     maxTokens: 131_072,
     thinkingLevelMap: {
-      off: "off",
+      off: "none",
       minimal: null,
       low: "low",
       medium: "medium",
@@ -202,7 +202,7 @@ export const MODELS: readonly ModelConfig[] = [
     contextWindow: 1_048_576,
     maxTokens: 131_072,
     thinkingLevelMap: {
-      off: "off",
+      off: "none",
       minimal: null,
       low: "low",
       medium: "medium",
@@ -219,7 +219,7 @@ export const MODELS: readonly ModelConfig[] = [
     contextWindow: 262_144,
     maxTokens: 131_072,
     thinkingLevelMap: {
-      off: "off",
+      off: "none",
       minimal: null,
       low: "low",
       medium: "medium",
@@ -237,7 +237,7 @@ export const MODELS: readonly ModelConfig[] = [
     contextWindow: 1_048_576,
     maxTokens: 131_072,
     thinkingLevelMap: {
-      off: "off",
+      off: "none",
       minimal: null,
       low: "low",
       medium: "medium",

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -65,6 +65,7 @@ describe("provider registration", () => {
       expect(models[i].cost).toEqual(MODELS[i].cost);
       expect(models[i].contextWindow).toBe(MODELS[i].contextWindow);
       expect(models[i].maxTokens).toBe(MODELS[i].maxTokens);
+      expect(models[i].thinkingLevelMap).toEqual(MODELS[i].thinkingLevelMap);
       expect(models[i].input).toEqual([...MODELS[i].input]);
       expect(Array.isArray(models[i].input)).toBe(true);
     }

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -56,10 +56,9 @@ describe("MODELS", () => {
   });
 
   it("models without an upstream xhigh tier restrict minimal and xhigh to null", () => {
-    // The Cline client only exposes reasoning effort as low/medium/high (plus
-    // "off"). It does not support "minimal" or "xhigh". Models whose upstream
-    // provider has no extra-high tier (e.g. z.ai "max") must map both minimal
-    // and xhigh to null.
+    // The Cline client only exposes reasoning effort as none/minimal/low/
+    // medium/high/xhigh. Models whose upstream provider has no extra-high tier
+    // (e.g. z.ai "max") must map both minimal and xhigh to null.
     const withoutXhigh = [
       "cline-pass/mimo-v2.5",
       "cline-pass/mimo-v2.5-pro",
@@ -76,8 +75,8 @@ describe("MODELS", () => {
       expect(map.low).toBe("low");
       expect(map.medium).toBe("medium");
       expect(map.high).toBe("high");
-      // "off" is explicitly supported — reasoning can be disabled.
-      expect(map.off).toBe("off");
+      // "off" is represented as "none" for the ClinePass API.
+      expect(map.off).toBe("none");
     }
   });
 
@@ -99,7 +98,7 @@ describe("MODELS", () => {
     for (const id of ["cline-pass/deepseek-v4-pro", "cline-pass/deepseek-v4-flash"]) {
       const model = MODELS.find((m) => m.id === id)!;
       const map = model.thinkingLevelMap;
-      expect(map.off).toBe("off");
+      expect(map.off).toBe("none");
       expect(map.minimal).toBeNull();
       expect(map.low).toBeNull();
       expect(map.medium).toBeNull();
@@ -111,7 +110,7 @@ describe("MODELS", () => {
   it("GLM-5.2 supports low/medium/high/xhigh (minimal unsupported)", () => {
     const model = MODELS.find((m) => m.id === "cline-pass/glm-5.2")!;
     const map = model.thinkingLevelMap;
-    expect(map.off).toBe("off");
+    expect(map.off).toBe("none");
     expect(map.minimal).toBeNull();
     expect(map.low).toBe("low");
     expect(map.medium).toBe("medium");

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   modelIds,
   MODELS,
+  DEFAULT_THINKING_LEVEL_MAP,
   fetchRemoteModels,
   resolveModels,
   NO_THINKING_MAP,
@@ -55,10 +56,21 @@ describe("MODELS", () => {
     }
   });
 
+  it("DEFAULT_THINKING_LEVEL_MAP maps pi off to Cline none", () => {
+    expect(DEFAULT_THINKING_LEVEL_MAP.off).toBe("none");
+  });
+
+  it("models that support disabling reasoning map pi off to Cline none", () => {
+    for (const model of MODELS) {
+      if (model.thinkingLevelMap.off === null) continue;
+      expect(model.thinkingLevelMap.off).toBe("none");
+    }
+  });
+
   it("models without an upstream xhigh tier restrict minimal and xhigh to null", () => {
-    // The Cline client only exposes reasoning effort as none/minimal/low/
-    // medium/high/xhigh. Models whose upstream provider has no extra-high tier
-    // (e.g. z.ai "max") must map both minimal and xhigh to null.
+    // The Cline client exposes reasoning effort levels (including "off", which
+    // maps to "none" for ClinePass). Models whose upstream provider has no
+    // extra-high tier (e.g. z.ai "max") must map both minimal and xhigh to null.
     const withoutXhigh = [
       "cline-pass/mimo-v2.5",
       "cline-pass/mimo-v2.5-pro",
@@ -116,6 +128,11 @@ describe("MODELS", () => {
     expect(map.medium).toBe("medium");
     expect(map.high).toBe("high");
     expect(map.xhigh).toBe("max");
+  });
+
+  it("maps pi off to none for GLM-5.2 (issue #17)", () => {
+    const glm = MODELS.find((m) => m.id === "cline-pass/glm-5.2")!;
+    expect(glm.thinkingLevelMap.off).toBe("none");
   });
 });
 
@@ -181,6 +198,7 @@ describe("fetchRemoteModels", () => {
     expect(result![0].contextWindow).toBe(200_000);
     expect(result![0].maxTokens).toBe(131_072);
     expect(result![0].reasoning).toBe(true);
+    expect(result![0].thinkingLevelMap.off).toBe("none");
     expect(result![0].cost.input).toBeCloseTo(1.4, 1);
     expect(result![0].cost.output).toBeCloseTo(4.4, 1);
   });
@@ -247,6 +265,20 @@ describe("fetchRemoteModels", () => {
     expect(result![0].thinkingLevelMap).toEqual(NO_THINKING_MAP);
   });
 
+  it("uses DEFAULT_THINKING_LEVEL_MAP for remote models without a static fallback", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [{ id: "cline-pass/new-model", name: "New Model", reasoning: true }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const result = await fetchRemoteModels({ apiKey: "test_key" });
+    expect(result).toHaveLength(1);
+    expect(result![0].thinkingLevelMap).toEqual(DEFAULT_THINKING_LEVEL_MAP);
+  });
+
   it("returns undefined for empty model list", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
       new Response(JSON.stringify({ data: [] }), {
@@ -300,5 +332,6 @@ describe("resolveModels", () => {
     expect(result[0].id).toBe("cline-pass/glm-5.2");
     expect(result[0].name).toBe("GLM-5.2 Updated");
     expect(result[1].id).toBe("cline-pass/new-model");
+    expect(result[1].thinkingLevelMap.off).toBe("none");
   });
 });


### PR DESCRIPTION
## What

- Changed the ClinePass thinking-level mapping so `off` now sends `reasoning_effort: "none"` instead of `"off"` for models that support disabling reasoning.
- Kept always-on models unchanged: `off` remains unsupported there (`null`).
- Updated unit tests to match the corrected mapping.

## Why

- The ClinePass API rejects `reasoning_effort: "off"` and expects `"none"` when reasoning is disabled.
- This was causing model requests like GLM-5.2 with thinking level `off` to fail with a 400 error.

## How

- Updated the default and model-specific thinking maps in `src/models.ts`.
- Adjusted unit test expectations in `tests/unit/models.test.ts`.
- Verified with `npm test`, `npm run lint`, and `npm run typecheck`.

## Checklist

- [x] Tests added or updated
- [x] Documentation updated where needed
- [x] No breaking changes (behavior is corrected for the API contract)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed “thinking off” behavior so models now correctly use a supported disabled-reasoning setting.
  * Improved compatibility for several models when reasoning is turned off, helping avoid request errors.
  * Added broader coverage to ensure fallback and remotely loaded models follow the same behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->