### PR TITLE
docs(agents): require implement-notes log for all AI tools

### DIFF
--- a/.planning/implement-notes.md
+++ b/.planning/implement-notes.md
@@ -23,5 +23,12 @@ _(append below — newest at bottom)_
 
 - **Context:** drafting AGENTS.md rule for cross-tool implementation logging
 - **Type:** learning
-- **Detail:** repo already had `.planning/codebase/` for static codebase maps; `.plans/implement-notes.md` is the session-scoped append log distinct from CONCERNS.md (tracked gaps) and ADRs (decisions)
+- **Detail:** repo already had `.planning/codebase/` for static codebase maps; `.planning/implement-notes.md` is the session-scoped append log distinct from CONCERNS.md (tracked gaps) and ADRs (decisions)
 - **Follow-up:** agents append here during work; link PRs/issues in follow-up lines when resolved
+
+### 2026-07-15 — consolidate implement-notes under .planning
+
+- **Context:** PR #25 review (Gemini Code Assist)
+- **Type:** learning
+- **Detail:** moved log from `.plans/` to `.planning/implement-notes.md` to avoid root dirs `.plans` vs `.planning`
+- **Follow-up:** addressed in commit for PR #25

--- a/.plans/implement-notes.md
+++ b/.plans/implement-notes.md
@@ -1,0 +1,27 @@
+# Implementation notes
+
+Append-only log for AI agents and contributors. Record blockers, issues, findings, and learnings discovered during implementation.
+
+**Rule:** all AI tools working in this repo must append here — see `AGENTS.md` → _Implementation notes (all AI tools)_.
+
+## Entry template
+
+```markdown
+### YYYY-MM-DD — short title
+
+- **Context:** what you were doing
+- **Type:** blocker | issue | finding | learning
+- **Detail:** what happened and why it matters
+- **Follow-up:** optional next step, PR, or issue link
+```
+
+## Entries
+
+_(append below — newest at bottom)_
+
+### 2026-07-07 — implement-notes rule added
+
+- **Context:** drafting AGENTS.md rule for cross-tool implementation logging
+- **Type:** learning
+- **Detail:** repo already had `.planning/codebase/` for static codebase maps; `.plans/implement-notes.md` is the session-scoped append log distinct from CONCERNS.md (tracked gaps) and ADRs (decisions)
+- **Follow-up:** agents append here during work; link PRs/issues in follow-up lines when resolved

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Models are referenced as `clinepass/cline-pass/<slug>` (e.g. `clinepass/cline-pa
 
 ## Implementation notes (all AI tools)
 
-During any implementation work — pi, Cursor, Codex, Claude Code, OpenCode, or other agents — **append** to `.plans/implement-notes.md` whenever you hit a blocker, discover an issue, uncover a non-obvious finding, or learn something worth preserving for the next session.
+During any implementation work — pi, Cursor, Codex, Claude Code, OpenCode, or other agents — **append** to `.planning/implement-notes.md` whenever you hit a blocker, discover an issue, uncover a non-obvious finding, or learn something worth preserving for the next session.
 
 - **When:** as soon as the item is known; do not defer to PR/merge time.
 - **What:** blockers (cannot proceed), issues (bugs/gaps), findings (surprising behaviour), learnings (conventions, API quirks, test tricks).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,17 @@ pi extension that registers `"clinepass"` as a model provider via pi's `openai-c
 
 Models are referenced as `clinepass/cline-pass/<slug>` (e.g. `clinepass/cline-pass/deepseek-v4-flash`). When invoking pi directly: `--model clinepass/cline-pass/...`.
 
+## Implementation notes (all AI tools)
+
+During any implementation work — pi, Cursor, Codex, Claude Code, OpenCode, or other agents — **append** to `.plans/implement-notes.md` whenever you hit a blocker, discover an issue, uncover a non-obvious finding, or learn something worth preserving for the next session.
+
+- **When:** as soon as the item is known; do not defer to PR/merge time.
+- **What:** blockers (cannot proceed), issues (bugs/gaps), findings (surprising behaviour), learnings (conventions, API quirks, test tricks).
+- **How:** one dated entry per item; append under `## Entries` (newest at bottom). See the file header for the entry template.
+- **Scope:** repo work only — no secrets, tokens, or personal data.
+
+This file is the handoff trail between agents and humans. If you resolve an item later, add a follow-up line under the same entry rather than deleting it.
+
 ## Commands
 
 | Command                 | What it does                                      |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+
+- **Thinking levels usage guide** — added Reasoning column to Supported Models table showing per-model thinking level capabilities (off/minimal/low/medium/high/xhigh), plus `--thinking` flag examples in Usage section ([#17](https://github.com/jellydn/pi-clinepass-provider/issues/17))
+- **Modular architecture** — documented 8 source modules (`env`, `auth`, `models`, `workos`, `oauth`, `error-handler`, `errors`, `utils`) + entry point in Features
+- **Unsupported level wording fix** — clarified that unsupported thinking levels are not sent to the API (model runs with its default reasoning behavior), not "without reasoning"
+- **GLM-5.2 reasoning matrix fix** — corrected table to exclude unsupported `minimal` level
+
 ## [1.1.1] — 2026-07-15
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,7 @@ Each commit should be atomic — one logical change per commit, staged explicitl
 - **CONCERNS.md** — `.planning/codebase/CONCERNS.md` tracks remaining technical concerns and coverage gaps.
 - **CONTEXT.md** — domain glossary of ClinePass-specific terms.
 - **AGENTS.md** — agent-facing guide (architecture overview, commands, gotchas).
+- **`.plans/implement-notes.md`** — append-only implementation log (blockers, issues, findings, learnings) for all AI tools; see AGENTS.md.
 
 ## Questions?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,7 @@ Each commit should be atomic — one logical change per commit, staged explicitl
 - **CONCERNS.md** — `.planning/codebase/CONCERNS.md` tracks remaining technical concerns and coverage gaps.
 - **CONTEXT.md** — domain glossary of ClinePass-specific terms.
 - **AGENTS.md** — agent-facing guide (architecture overview, commands, gotchas).
-- **`.plans/implement-notes.md`** — append-only implementation log (blockers, issues, findings, learnings) for all AI tools; see AGENTS.md.
+- **`.planning/implement-notes.md`** — append-only implementation log (blockers, issues, findings, learnings) for all AI tools; see AGENTS.md.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -40,29 +40,33 @@ pnpm add pi-clinepass-provider
 
 ## Features
 
-- Full streaming via Cline's OpenAI-compatible `/api/v1/chat/completions` endpoint
-- Per-token cost tracking against ClinePass reference pricing
+- **Full streaming** via Cline's OpenAI-compatible `/api/v1/chat/completions` endpoint — SSE parsing, tool calls, and usage tracking handled by pi's built-in `openai-completions` streaming
+- **Per-model thinking level support** — maps pi's 6 thinking levels (`off` / `minimal` / `low` / `medium` / `high` / `xhigh`) to provider-specific `reasoning_effort` values, with per-model capability matrices (see table below)
+- **Per-token cost tracking** against ClinePass reference pricing
 - **WorkOS OAuth token refresh** — reuses your existing Cline CLI login (`cline auth`); no separate API key needed
-- API key auto-discovery from `CLINE_API_KEY` env var, `~/.cline/data/settings/providers.json`, or `~/.pi/agent/auth.json`
+- **API key auto-discovery** from `CLINE_API_KEY` env var, `~/.cline/data/settings/providers.json`, or `~/.pi/agent/auth.json`
 - **Dynamic model discovery** — fetches the live model list from the Cline API at startup, falling back to a curated static list on error
-- `/login` integration — automatic WorkOS OAuth detection or browser-assisted manual paste
+- **`/login` integration** — automatic WorkOS OAuth detection or browser-assisted manual paste
+- **Modular architecture** — 8 focused source modules (`env`, `auth`, `models`, `workos`, `oauth`, `error-handler`, `errors`, `utils`) + entry point (`index`), all covered by per-module unit tests
 
 ## Supported Models
 
 ![Models](models.png)
 
-| Model             | Model ID                       | Context |
-| :---------------- | :----------------------------- | :------ |
-| GLM-5.2           | `cline-pass/glm-5.2`           | 200K    |
-| Kimi K2.7 Code    | `cline-pass/kimi-k2.7-code`    | 262K    |
-| Kimi K2.6         | `cline-pass/kimi-k2.6`         | 262K    |
-| DeepSeek V4 Pro   | `cline-pass/deepseek-v4-pro`   | 1M      |
-| DeepSeek V4 Flash | `cline-pass/deepseek-v4-flash` | 1M      |
-| MiMo-V2.5         | `cline-pass/mimo-v2.5`         | 262K    |
-| MiMo-V2.5-Pro     | `cline-pass/mimo-v2.5-pro`     | 262K    |
-| MiniMax M3        | `cline-pass/minimax-m3`        | 1M      |
-| Qwen3.7 Max       | `cline-pass/qwen3.7-max`       | 262K    |
-| Qwen3.7 Plus      | `cline-pass/qwen3.7-plus`      | 1M      |
+| Model             | Model ID                       | Context | Reasoning                         |
+| :---------------- | :----------------------------- | :------ | :-------------------------------- |
+| GLM-5.2           | `cline-pass/glm-5.2`           | 200K    | off / low / medium / high / xhigh |
+| Kimi K2.7 Code    | `cline-pass/kimi-k2.7-code`    | 262K    | low / medium / high               |
+| Kimi K2.6         | `cline-pass/kimi-k2.6`         | 262K    | low / medium / high               |
+| DeepSeek V4 Pro   | `cline-pass/deepseek-v4-pro`   | 1M      | off + high (high used for xhigh)  |
+| DeepSeek V4 Flash | `cline-pass/deepseek-v4-flash` | 1M      | off + high (high used for xhigh)  |
+| MiMo-V2.5         | `cline-pass/mimo-v2.5`         | 262K    | off / low / medium / high         |
+| MiMo-V2.5-Pro     | `cline-pass/mimo-v2.5-pro`     | 262K    | off / low / medium / high         |
+| MiniMax M3        | `cline-pass/minimax-m3`        | 1M      | off / low / medium / high         |
+| Qwen3.7 Max       | `cline-pass/qwen3.7-max`       | 262K    | off / low / medium / high         |
+| Qwen3.7 Plus      | `cline-pass/qwen3.7-plus`      | 1M      | off / low / medium / high         |
+
+> **Thinking levels**: pi supports 6 levels — `off`, `minimal`, `low`, `medium`, `high`, `xhigh`. Each model declares which levels it supports, mapped to the provider's `reasoning_effort` parameter. Set the thinking level with pi's `--thinking` flag or `/thinking` command. A level marked as unsupported (not listed above) maps to `null` — no `reasoning_effort` is sent to the API, so the model runs with its default reasoning behavior.
 
 ## Authentication
 
@@ -122,6 +126,23 @@ pi --model clinepass/cline-pass/glm-5.2 --trust "Refactor the auth module"
 ```
 
 Switch models in-session with `/model clinepass/cline-pass/glm-5.2`.
+
+### Thinking levels
+
+Set the reasoning effort per model using pi's `--thinking` flag or the in-session `/thinking` command:
+
+```sh
+# Use high reasoning with DeepSeek V4 Pro
+pi --model clinepass/cline-pass/deepseek-v4-pro --thinking high -p "Design a scalable microservice architecture"
+
+# GLM-5.2 supports five levels up to xhigh
+pi --model clinepass/cline-pass/glm-5.2 --thinking xhigh -p "Solve this complex math proof"
+
+# Disable reasoning for a quick code gen task
+pi --model clinepass/cline-pass/deepseek-v4-flash --thinking off -p "Write a React form component"
+```
+
+Each model's supported thinking levels are listed in the [Supported Models](#supported-models) table above. Unsupported levels are not sent to the API — the model runs with its default reasoning behavior.
 
 ## Run tests
 


### PR DESCRIPTION
## What

- Add **Implementation notes (all AI tools)** section to `AGENTS.md`
- Scaffold `.plans/implement-notes.md` with entry template and first example entry
- Cross-reference the log in `CONTRIBUTING.md` documentation list

## Why

Agents working across pi, Cursor, Codex, and other tools need a shared, append-only trail of blockers, issues, findings, and learnings during implementation — not only at PR time. This complements static docs (`.planning/codebase/CONCERNS.md`, ADRs) with session-scoped handoff notes.

## How

- Rule: append dated entries under `## Entries` as discoveries happen; no secrets; resolve via follow-up lines, never delete
- Entry types: blocker | issue | finding | learning
- Template lives in the file header; AGENTS.md points all AI tools at it

## Checklist

- [x] Tests added or updated (N/A — docs only)
- [x] Documentation updated
- [x] No breaking changes (or breaking changes documented above)

Made with [Cursor](https://cursor.com)