### PR TITLE
fix: make apiKey config conditional on environment variable presence

### DIFF
--- a/.changeset/fix-apikey-env-sigil.md
+++ b/.changeset/fix-apikey-env-sigil.md
@@ -1,0 +1,5 @@
+---
+"pi-clinepass-provider": patch
+---
+
+fix: make apiKey config conditional on environment variable presence

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,9 +44,9 @@ export default async function (pi: ExtensionAPI) {
   const apiKey = resolveApiKey();
   const models = await resolveModels(apiKey, { apiBase });
 
-  // Only register apiKey config when the environment variable is actually set.
-  // Otherwise the literal "$CLINE_API_KEY" would be sent as bearer token,
-  // overriding OAuth and causing 401 errors.
+  // Only register the $CLINE_API_KEY sigil when the env var is set at extension
+  // load time. OAuth-only installs should not advertise an unconfigured env-key
+  // fallback; when present, the $… form resolves the secret at request time.
   const envApiKey = process.env[ENV_API_KEY]?.trim();
 
   pi.registerProvider(PROVIDER_NAME, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ export default async function (pi: ExtensionAPI) {
   pi.registerProvider(PROVIDER_NAME, {
     name: "ClinePass",
     baseUrl: `${apiBase}/api/v1`,
-    ...(envApiKey ? { apiKey: ENV_API_KEY } : {}),
+    ...(envApiKey ? { apiKey: `$${ENV_API_KEY}` } : {}),
     authHeader: true,
     // ClinePass uses the standard OpenAI Chat Completions format, so pi's
     // built-in openai-completions streaming handles SSE + tool calls + usage.

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,10 +44,15 @@ export default async function (pi: ExtensionAPI) {
   const apiKey = resolveApiKey();
   const models = await resolveModels(apiKey, { apiBase });
 
+  // Only register apiKey config when the environment variable is actually set.
+  // Otherwise the literal "$CLINE_API_KEY" would be sent as bearer token,
+  // overriding OAuth and causing 401 errors.
+  const envApiKey = process.env[ENV_API_KEY]?.trim();
+
   pi.registerProvider(PROVIDER_NAME, {
     name: "ClinePass",
     baseUrl: `${apiBase}/api/v1`,
-    apiKey: `$${ENV_API_KEY}`,
+    ...(envApiKey ? { apiKey: ENV_API_KEY } : {}),
     authHeader: true,
     // ClinePass uses the standard OpenAI Chat Completions format, so pi's
     // built-in openai-completions streaming handles SSE + tool calls + usage.

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -14,10 +14,12 @@ import { MODELS } from "../../src/models.js";
 describe("provider registration", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("Not Found", { status: 404 })));
+    vi.stubEnv(ENV_API_KEY, "");
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("registers with correct baseUrl, apiKey, and api type", async () => {
@@ -36,40 +38,26 @@ describe("provider registration", () => {
     expect(captured).toBeDefined();
     expect(captured!.name).toBe(PROVIDER_NAME);
     expect(captured!.config.baseUrl).toBe(`${DEFAULT_API_BASE}/api/v1`);
-    // apiKey is only registered when CLINE_API_KEY env var is set;
-    // otherwise it's undefined (OAuth handles auth)
     expect(captured!.config.apiKey).toBeUndefined();
     expect(captured!.config.api).toBe("openai-completions");
     expect(captured!.config.authHeader).toBe(true);
   });
 
   it("registers apiKey config when CLINE_API_KEY env var is set", async () => {
-    // This test intentionally uses dynamic import because index.ts is a module
-    // that needs fresh evaluation with the env var set.
-    const original = process.env[ENV_API_KEY];
-    process.env[ENV_API_KEY] = "test-key-123";
-    try {
-      let captured: { name: string; config: Record<string, unknown> } | undefined;
-      const fakePi = {
-        registerProvider: (name: string, config: Record<string, unknown>) => {
-          captured = { name, config };
-        },
-        on: () => {},
-      };
+    vi.stubEnv(ENV_API_KEY, "test-key-123");
+    let captured: { name: string; config: Record<string, unknown> } | undefined;
+    const fakePi = {
+      registerProvider(name: string, config: Record<string, unknown>) {
+        captured = { name, config };
+      },
+      on(_event: string, _handler: unknown) {},
+    };
 
-      // Re-import to get fresh module evaluation with env var set
-      const mod = await import("../../src/index.js?t=" + Date.now());
-      await mod.default(fakePi as never);
+    const mod = await import("../../src/index.js");
+    await mod.default(fakePi as never);
 
-      expect(captured).toBeDefined();
-      expect(captured!.config.apiKey).toBe(`$${ENV_API_KEY}`);
-    } finally {
-      if (original !== undefined) {
-        process.env[ENV_API_KEY] = original;
-      } else {
-        delete process.env[ENV_API_KEY];
-      }
-    }
+    expect(captured).toBeDefined();
+    expect(captured!.config.apiKey).toBe(`$${ENV_API_KEY}`);
   });
 
   it("registers all static models as fallback when API is unavailable", async () => {

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -22,7 +22,7 @@ describe("provider registration", () => {
     vi.unstubAllEnvs();
   });
 
-  it("registers with correct baseUrl, apiKey, and api type", async () => {
+  it("registers with correct baseUrl, no apiKey when env unset, and api type", async () => {
     let captured: { name: string; config: Record<string, unknown> } | undefined;
 
     const fakePi = {

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -36,9 +36,40 @@ describe("provider registration", () => {
     expect(captured).toBeDefined();
     expect(captured!.name).toBe(PROVIDER_NAME);
     expect(captured!.config.baseUrl).toBe(`${DEFAULT_API_BASE}/api/v1`);
-    expect(captured!.config.apiKey).toBe(`$${ENV_API_KEY}`);
+    // apiKey is only registered when CLINE_API_KEY env var is set;
+    // otherwise it's undefined (OAuth handles auth)
+    expect(captured!.config.apiKey).toBeUndefined();
     expect(captured!.config.api).toBe("openai-completions");
     expect(captured!.config.authHeader).toBe(true);
+  });
+
+  it("registers apiKey config when CLINE_API_KEY env var is set", async () => {
+    // This test intentionally uses dynamic import because index.ts is a module
+    // that needs fresh evaluation with the env var set.
+    const original = process.env[ENV_API_KEY];
+    process.env[ENV_API_KEY] = "test-key-123";
+    try {
+      let captured: { name: string; config: Record<string, unknown> } | undefined;
+      const fakePi = {
+        registerProvider: (name: string, config: Record<string, unknown>) => {
+          captured = { name, config };
+        },
+        on: () => {},
+      };
+
+      // Re-import to get fresh module evaluation with env var set
+      const mod = await import("../../src/index.js?t=" + Date.now());
+      await mod.default(fakePi as never);
+
+      expect(captured).toBeDefined();
+      expect(captured!.config.apiKey).toBe(ENV_API_KEY);
+    } finally {
+      if (original !== undefined) {
+        process.env[ENV_API_KEY] = original;
+      } else {
+        delete process.env[ENV_API_KEY];
+      }
+    }
   });
 
   it("registers all static models as fallback when API is unavailable", async () => {

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -62,7 +62,7 @@ describe("provider registration", () => {
       await mod.default(fakePi as never);
 
       expect(captured).toBeDefined();
-      expect(captured!.config.apiKey).toBe(ENV_API_KEY);
+      expect(captured!.config.apiKey).toBe(`$${ENV_API_KEY}`);
     } finally {
       if (original !== undefined) {
         process.env[ENV_API_KEY] = original;


### PR DESCRIPTION
## Problem

When `CLINE_API_KEY` is not set in the environment, the provider registers `apiKey: '$CLINE_API_KEY'` in the config. OMP's model registry resolves this by looking up the entire string as an environment variable name, finds nothing, and falls back to using the literal string as the bearer token. This overrides valid OAuth credentials and causes 401 errors:

> "Please make sure you're using the latest version of Cline and re-authenticate"

The Cline API returns the same error message for both expired tokens and literal invalid tokens, making this hard to diagnose.

## Root Cause

`config.apiKey` has higher priority than stored OAuth credentials in OMP's auth resolution order (runtime > config > oauth). So the literal string always wins over OAuth.

## Fix

Only register `apiKey` in the provider config when the environment variable is actually set:

```typescript
const envApiKey = process.env[ENV_API_KEY]?.trim();

pi.registerProvider(PROVIDER_NAME, {
  // ...
  ...(envApiKey ? { apiKey: ENV_API_KEY } : {}),
  // ...
});
```

- **Env var set** → apiKey is registered, OMP resolves it to the real key
- **Env var unset** → apiKey is omitted, OAuth handles authentication

## Testing

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` — 149/149 tests pass
- Updated existing test assertion and added new test case for both branches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed provider authentication to only configure the API key when the relevant environment variable is set and non-empty (after trimming), preventing accidental use of a placeholder value that could trigger 401 errors.
* **Tests**
  * Updated provider registration unit tests to assert the API key is omitted when unset.
  * Added a test to verify correct API key wiring when set, including proper environment cleanup after execution.
* **Release Notes**
  * Added a patch changeset to document the conditional API key behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->