### PR TITLE
docs(readme): link opencode-clinepass-provider in Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ prek install
 
 ## Resources
 
-- **[opencode-clinepass-provider](https://github.com/haconglinh1990/opencode-clinepass-provider)** — ClinePass provider for [OpenCode](https://github.com/sst/opencode); same subscription and models outside pi.
+- **[opencode-clinepass-provider](https://github.com/haconglinh1990/opencode-clinepass-provider)** — ClinePass provider for [OpenCode](https://github.com/sst/opencode); same subscription and models outside of pi.
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ prek install
 - **Context windows**: estimates from ClinePass docs — verify against Cline's `/models` endpoint.
 - **Custom API base**: set `CLINE_API_BASE` env var to override the endpoint (default: `https://api.cline.bot`).
 
+## Resources
+
+- **[opencode-clinepass-provider](https://github.com/haconglinh1990/opencode-clinepass-provider)** — ClinePass provider for [OpenCode](https://github.com/sst/opencode); same subscription and models outside pi.
+
 ## 📄 License
 
 This project is licensed under the **MIT License** - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Adds a **Resources** section to README with [opencode-clinepass-provider](https://github.com/haconglinh1990/opencode-clinepass-provider) for OpenCode users on the same ClinePass subscription.