### PR TITLE
fix: ClinePass rejects developer role (GLM-5.2, #31)

### DIFF
--- a/.changeset/fix-developer-role.md
+++ b/.changeset/fix-developer-role.md
@@ -1,0 +1,5 @@
+---
+"pi-clinepass-provider": patch
+---
+
+fix: set supportsDeveloperRole false so ClinePass accepts system prompts (fixes #31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Developer role rejected by ClinePass API** — set `compat.supportsDeveloperRole: false` on all models so pi sends `system` instead of `developer`, fixing 400 errors on GLM-5.2 and other ClinePass models ([#31](https://github.com/jellydn/pi-clinepass-provider/issues/31))
 - **WorkOS login refresh hardening** — pick the freshest credentials across `cline-pass`, `cline`, and pi `auth.json`; fall back to manual API-key paste when subscription refresh fails ([#16](https://github.com/jellydn/pi-clinepass-provider/issues/16))
 
 ## [1.0.6] — 2026-07-06

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,13 +25,11 @@ import { resolveModels } from "./models.js";
 import { handleClinePassError } from "./error-handler.js";
 import { getApiKey as oauthGetApiKey, login, refreshToken } from "./oauth.js";
 
-// Note on compat/thinkingFormat: ClinePass exposes a standard OpenAI-compatible
-// Chat Completions API (per docs.cline.bot). Cline's infrastructure normalizes
-// the upstream models (GLM, Kimi, DeepSeek, etc.) to this format, so pi's
-// built-in openai-completions streaming and default thinking handling work
-// without per-model compat overrides. If reasoning is found to not work
-// correctly for a specific model through the live API, add a model-level
-// compat override here (e.g. compat: { thinkingFormat: "zai" } for GLM).
+// ClinePass exposes OpenAI-compatible chat completions, but rejects the
+// `developer` role pi-ai uses by default for reasoning models. Every model
+// declares `compat.supportsDeveloperRole: false` in models.ts so system
+// prompts use `system`. Per-model thinkingFormat overrides remain available
+// if a specific upstream model needs them (e.g. compat.thinkingFormat: "zai").
 
 // ─── Extension Entry Point ─────────────────────────────────────────────────
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -47,6 +47,19 @@ export const NO_THINKING_MAP: ThinkingLevelMap = {
 };
 
 /**
+ * OpenAI-compat flags for ClinePass chat completions.
+ *
+ * ClinePass only accepts classic roles (`system`, `assistant`, `user`, `tool`,
+ * `function`). pi-ai defaults to `developer` for reasoning models unless
+ * `supportsDeveloperRole` is false (see pi-ai README).
+ */
+export const CLINEPASS_OPENAI_COMPAT = {
+  supportsDeveloperRole: false,
+} as const;
+
+export type ClinePassOpenAICompat = typeof CLINEPASS_OPENAI_COMPAT;
+
+/**
  * ClinePass curated open-weight coding models.
  *
  * Model IDs use the full ClinePass slug (e.g. "cline-pass/glm-5.2") as
@@ -71,9 +84,14 @@ export interface ModelConfig {
    * declare all six levels explicitly — there are no implicit defaults.
    */
   thinkingLevelMap: ThinkingLevelMap;
+  /** pi-ai openai-completions compat overrides for the ClinePass API. */
+  compat: ClinePassOpenAICompat;
 }
 
-export const MODELS: readonly ModelConfig[] = [
+/** Static catalog entries before ClinePass-wide compat is attached. */
+type ModelConfigBase = Omit<ModelConfig, "compat">;
+
+const MODELS_BASE: readonly ModelConfigBase[] = [
   {
     id: "cline-pass/glm-5.2",
     name: "GLM-5.2 (ClinePass)",
@@ -247,6 +265,11 @@ export const MODELS: readonly ModelConfig[] = [
   },
 ];
 
+export const MODELS: readonly ModelConfig[] = MODELS_BASE.map((model) => ({
+  ...model,
+  compat: CLINEPASS_OPENAI_COMPAT,
+}));
+
 /**
  * Return the model IDs registered for the ClinePass provider.
  */
@@ -315,6 +338,7 @@ function parseRemoteModel(raw: RawModelEntry, fallback?: ModelConfig): ModelConf
     thinkingLevelMap: reasoning
       ? (fallback?.thinkingLevelMap ?? DEFAULT_THINKING_LEVEL_MAP)
       : NO_THINKING_MAP,
+    compat: fallback?.compat ?? CLINEPASS_OPENAI_COMPAT,
   };
 }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -53,11 +53,14 @@ export const NO_THINKING_MAP: ThinkingLevelMap = {
  * `function`). pi-ai defaults to `developer` for reasoning models unless
  * `supportsDeveloperRole` is false (see pi-ai README).
  */
-export const CLINEPASS_OPENAI_COMPAT = {
-  supportsDeveloperRole: false,
-} as const;
+export interface ClinePassOpenAICompat {
+  readonly supportsDeveloperRole: boolean;
+  readonly thinkingFormat?: string;
+}
 
-export type ClinePassOpenAICompat = typeof CLINEPASS_OPENAI_COMPAT;
+export const CLINEPASS_OPENAI_COMPAT: ClinePassOpenAICompat = {
+  supportsDeveloperRole: false,
+};
 
 /**
  * ClinePass curated open-weight coding models.
@@ -88,8 +91,10 @@ export interface ModelConfig {
   compat: ClinePassOpenAICompat;
 }
 
-/** Static catalog entries before ClinePass-wide compat is attached. */
-type ModelConfigBase = Omit<ModelConfig, "compat">;
+/** Static catalog entries; per-model compat overrides merge with CLINEPASS_OPENAI_COMPAT. */
+interface ModelConfigBase extends Omit<ModelConfig, "compat"> {
+  compat?: Partial<ClinePassOpenAICompat>;
+}
 
 const MODELS_BASE: readonly ModelConfigBase[] = [
   {
@@ -267,7 +272,10 @@ const MODELS_BASE: readonly ModelConfigBase[] = [
 
 export const MODELS: readonly ModelConfig[] = MODELS_BASE.map((model) => ({
   ...model,
-  compat: CLINEPASS_OPENAI_COMPAT,
+  compat: {
+    ...CLINEPASS_OPENAI_COMPAT,
+    ...model.compat,
+  },
 }));
 
 /**
@@ -338,7 +346,10 @@ function parseRemoteModel(raw: RawModelEntry, fallback?: ModelConfig): ModelConf
     thinkingLevelMap: reasoning
       ? (fallback?.thinkingLevelMap ?? DEFAULT_THINKING_LEVEL_MAP)
       : NO_THINKING_MAP,
-    compat: fallback?.compat ?? CLINEPASS_OPENAI_COMPAT,
+    compat: {
+      ...CLINEPASS_OPENAI_COMPAT,
+      ...fallback?.compat,
+    },
   };
 }
 

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -85,6 +85,7 @@ describe("provider registration", () => {
       expect(models[i].contextWindow).toBe(MODELS[i].contextWindow);
       expect(models[i].maxTokens).toBe(MODELS[i].maxTokens);
       expect(models[i].thinkingLevelMap).toEqual(MODELS[i].thinkingLevelMap);
+      expect(models[i].compat).toEqual(MODELS[i].compat);
       expect(models[i].input).toEqual([...MODELS[i].input]);
       expect(Array.isArray(models[i].input)).toBe(true);
     }

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   modelIds,
   MODELS,
+  CLINEPASS_OPENAI_COMPAT,
   DEFAULT_THINKING_LEVEL_MAP,
   fetchRemoteModels,
   resolveModels,
@@ -134,6 +135,13 @@ describe("MODELS", () => {
     const glm = MODELS.find((m) => m.id === "cline-pass/glm-5.2")!;
     expect(glm.thinkingLevelMap.off).toBe("none");
   });
+
+  it("declares supportsDeveloperRole: false for every model (issue #31)", () => {
+    for (const model of MODELS) {
+      expect(model.compat).toEqual(CLINEPASS_OPENAI_COMPAT);
+      expect(model.compat.supportsDeveloperRole).toBe(false);
+    }
+  });
 });
 
 // ─── fetchRemoteModels ─────────────────────────────────────────────────────
@@ -201,6 +209,7 @@ describe("fetchRemoteModels", () => {
     expect(result![0].thinkingLevelMap.off).toBe("none");
     expect(result![0].cost.input).toBeCloseTo(1.4, 1);
     expect(result![0].cost.output).toBeCloseTo(4.4, 1);
+    expect(result![0].compat.supportsDeveloperRole).toBe(false);
   });
 
   it("parses bare array response format", async () => {
@@ -248,6 +257,7 @@ describe("fetchRemoteModels", () => {
     expect(result![0].contextWindow).toBe(staticModel!.contextWindow);
     expect(result![0].maxTokens).toBe(staticModel!.maxTokens);
     expect(result![0].cost.input).toBe(staticModel!.cost.input);
+    expect(result![0].compat).toEqual(staticModel!.compat);
   });
 
   it("uses NO_THINKING_MAP when remote model reports reasoning: false", async () => {
@@ -277,6 +287,7 @@ describe("fetchRemoteModels", () => {
     const result = await fetchRemoteModels({ apiKey: "test_key" });
     expect(result).toHaveLength(1);
     expect(result![0].thinkingLevelMap).toEqual(DEFAULT_THINKING_LEVEL_MAP);
+    expect(result![0].compat.supportsDeveloperRole).toBe(false);
   });
 
   it("returns undefined for empty model list", async () => {


### PR DESCRIPTION
## Summary

Fixes [#31](https://github.com/jellydn/pi-clinepass-provider/issues/31): ClinePass returns **400** when pi sends messages with role `developer` (pi-ai default for reasoning models). The API only allows `system`, `assistant`, `user`, `tool`, `function`.

## Change

- Add `CLINEPASS_OPENAI_COMPAT` with `supportsDeveloperRole: false` on every static and dynamically discovered model (`src/models.ts`).
- Registration already spreads model fields into `registerProvider`, so pi-ai uses `system` for the system prompt.

## Verification

- `npm test` (150 tests)
- `npm run typecheck`
- `npm run lint`

## After release

Please retest in **pi** with **ClinePass GLM-5.2** (and any other models that failed with the developer-role error) on the published version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ClinePass compatibility by sending system prompts instead of developer-role messages.
  * Resolved 400 errors affecting GLM-5.2 and other ClinePass models.
  * Applied the compatibility behavior consistently to both built-in and remotely discovered models.

* **Documentation**
  * Updated compatibility documentation and the unreleased changelog to reflect the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->