### PR TITLE
feat(models): add kimi-k3 to static catalog

### DIFF
--- a/.changeset/add-kimi-k3.md
+++ b/.changeset/add-kimi-k3.md
@@ -1,0 +1,7 @@
+---
+"pi-clinepass-provider": minor
+---
+
+feat: add Kimi K3 to the ClinePass static model catalog
+
+Adds `cline-pass/kimi-k3` with its context window, output limit, reference pricing, and always-on reasoning configuration.

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -110,7 +110,7 @@
 **`ModelConfig` + `thinkingLevelMap`:**
 
 - Purpose: Declares a model's capabilities and the explicit mapping of pi's 6 thinking levels (`off|minimal|low|medium|high|xhigh`) to ClinePass `reasoning_effort` strings, or `null` (unsupported).
-- Examples: `src/models.ts` (10 static models + `DEFAULT_THINKING_LEVEL_MAP` / `NO_THINKING_MAP` for remote models).
+- Examples: `src/models.ts` (11 static models + `DEFAULT_THINKING_LEVEL_MAP` / `NO_THINKING_MAP` for remote models).
 - Pattern: Readonly `Record<ThinkingLevel, string|null>` — every model must declare all six levels (no implicit defaults). `off` maps to `"none"` for models that can disable reasoning; `null` for always-reasoning models (Kimi).
 
 **Injectable I/O options:**

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -13,7 +13,7 @@
 
 **`src/models.ts` exceeds the 300-line guideline:**
 
-- Issue: CONTRIBUTING.md states "Files should stay under 300 lines. If a module grows beyond that, extract a sub-module." `models.ts` is 412 lines — driven by the 10-entry static `MODELS` catalog (each with a 6-level `thinkingLevelMap`) plus the dynamic-discovery logic.
+- Issue: CONTRIBUTING.md states "Files should stay under 300 lines. If a module grows beyond that, extract a sub-module." `models.ts` is 466 lines — driven by the 11-entry static `MODELS` catalog (each with a 6-level `thinkingLevelMap`) plus the dynamic-discovery logic.
 - Files: `src/models.ts`
 - Impact: Mild — the catalog is repetitive data, not complex logic; locality is still good. But it sets a precedent for ignoring the guideline as more models are added.
 - Fix approach: Either (a) extract the static `MODELS` array into `src/models/static-catalog.ts` and keep `models.ts` for types + discovery, or (b) raise the guideline explicitly for data-table modules. Low priority; revisit when the catalog grows past ~15 models.
@@ -69,7 +69,7 @@ None significant. The extension is stateless after registration. Startup does on
 
 **Model catalog growth:**
 
-- Current capacity: 10 static models, 412-line `models.ts`.
+- Current capacity: 11 static models, 466-line `models.ts`.
 - Limit: No hard limit; each model adds ~25 lines. The 300-line guideline will be increasingly violated.
 - Scaling path: Extract static catalog to its own module (see Tech Debt above) or move to a data file (JSON/TS data table) parsed at load.
 

--- a/.planning/implement-notes.md
+++ b/.planning/implement-notes.md
@@ -45,4 +45,4 @@ _(append below — newest at bottom)_
 - **Context:** reviewing the Kimi K3 catalog entry before a public PR
 - **Type:** issue
 - **Detail:** Kimi documents K3 as always-on reasoning with only `reasoning_effort: "max"`; mapping pi `off` to `"none"` can send an unsupported provider value.
-- **Follow-up:** set `off` to `null` and added an explicit K3 thinking-map unit test. Attempted live validation, but `CLINE_API_KEY` is not set in this environment; `cline-pass/kimi-k3` plus `"max"` still requires a live ClinePass validation before merge.
+- **Follow-up:** set `off` to `null` and added an explicit K3 thinking-map unit test. The contributor manually confirmed a successful ClinePass completion with `cline-pass/kimi-k3` and pi `--thinking high` (`reasoning_effort: "max"`).

--- a/.planning/implement-notes.md
+++ b/.planning/implement-notes.md
@@ -32,3 +32,17 @@ _(append below — newest at bottom)_
 - **Type:** learning
 - **Detail:** moved log from `.plans/` to `.planning/implement-notes.md` to avoid root dirs `.plans` vs `.planning`
 - **Follow-up:** addressed in commit for PR #25
+
+### 2026-07-19 — add Kimi K3 static catalog entry
+
+- **Context:** adding `cline-pass/kimi-k3` to static model catalog in `src/models.ts`
+- **Type:** learning
+- **Detail:** local env lacked project deps initially (`vitest` missing); running `npm install` was required before tests could execute.
+- **Follow-up:** run `npm test` after `npm install` in fresh environments.
+
+### 2026-07-19 — Kimi K3 reasoning-level review finding
+
+- **Context:** reviewing the Kimi K3 catalog entry before a public PR
+- **Type:** issue
+- **Detail:** Kimi documents K3 as always-on reasoning with only `reasoning_effort: "max"`; mapping pi `off` to `"none"` can send an unsupported provider value.
+- **Follow-up:** set `off` to `null` and added an explicit K3 thinking-map unit test. Attempted live validation, but `CLINE_API_KEY` is not set in this environment; `cline-pass/kimi-k3` plus `"max"` still requires a live ClinePass validation before merge.

--- a/.planning/implement-notes.md
+++ b/.planning/implement-notes.md
@@ -46,3 +46,10 @@ _(append below — newest at bottom)_
 - **Type:** issue
 - **Detail:** Kimi documents K3 as always-on reasoning with only `reasoning_effort: "max"`; mapping pi `off` to `"none"` can send an unsupported provider value.
 - **Follow-up:** set `off` to `null` and added an explicit K3 thinking-map unit test. The contributor manually confirmed a successful ClinePass completion with `cline-pass/kimi-k3` and pi `--thinking high` (`reasoning_effort: "max"`).
+
+### 2026-07-19 — PR review reply API payload
+
+- **Context:** replying to inline GitHub review comments on PR #43
+- **Type:** learning
+- **Detail:** GitHub's review-comment REST endpoint requires `in_reply_to` as a JSON number; `gh api -f` serializes it as a string and is rejected.
+- **Follow-up:** use `gh api --input` with a JSON payload for inline replies.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ This file is the handoff trail between agents and humans. If you resolve an item
 - **`src/index.ts`** — Entry. Calls `pi.registerProvider()`, wires models + OAuth + error handler.
 - **`src/env.ts`** — Constants (`DEFAULT_API_BASE`, `ENV_API_KEY`, `PROVIDER_NAME`), `resolveApiBase()`, `sanitizeApiKey()`, `buildEndpointUrl()`.
 - **`src/auth.ts`** — API key resolution chain: env var → `~/.cline/data/settings/providers.json` → `~/.pi/agent/auth.json`. Shared `walkAuthPaths()` / `walkClineProviderSettings()` utilities used by both auth and workos modules.
-- **`src/models.ts`** — Static model definitions (10 curated models with pricing + thinking level maps) and dynamic model discovery (`fetchRemoteModels`, `resolveModels`). 5-second fetch timeout.
+- **`src/models.ts`** — Static model definitions (11 curated models with pricing + thinking level maps) and dynamic model discovery (`fetchRemoteModels`, `resolveModels`). 5-second fetch timeout.
 - **`src/workos.ts`** — WorkOS OAuth protocol adapter: credential extraction from providers.json and `~/.pi/agent/auth.json`, token refresh via Cline's `/api/v1/auth/refresh`, `isWorkosToken()` check.
 - **`src/oauth.ts`** — `/login` flow: auto-detects existing WorkOS credentials, falls back to browser-assisted manual API key paste. `refreshToken()` delegates to WorkOS refresh or returns static key unchanged.
 - **`src/error-handler.ts`** + **`src/errors.ts`** — `message_end` handler that classifies ClinePass 401/403/429 errors into user-friendly notifications.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,7 +53,7 @@ A JSON file that pi uses to persist OAuth credentials. Two formats exist:
 
 ### Static Model Catalog
 
-A hardcoded list of 10 curated models (GLM-5.2, Kimi K2.7 Code, Kimi K2.6, DeepSeek V4 Pro, DeepSeek V4 Flash, MiMo-V2.5, MiMo-V2.5-Pro, MiniMax M3, Qwen3.7 Max, Qwen3.7 Plus) with reference pricing, context windows, and token limits.
+A hardcoded list of 11 curated models (GLM-5.2, Kimi K2.7 Code, Kimi K2.6, Kimi K3, DeepSeek V4 Pro, DeepSeek V4 Flash, MiMo-V2.5, MiMo-V2.5-Pro, MiniMax M3, Qwen3.7 Max, Qwen3.7 Plus) with reference pricing, context windows, and token limits.
 
 ### Dynamic Model Discovery
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/jellydn/pi-clinepass-provider/workflows/CI/badge.svg)](https://github.com/jellydn/pi-clinepass-provider/actions)
 
-> ClinePass provider for [pi](https://github.com/earendil-works/pi) — 10 curated open-weight coding models (GLM-5.2, Kimi K2.7 Code, DeepSeek V4, Qwen3.7, and more) through Cline's $9.99/month subscription with 2-5x standard API rate limits.
+> ClinePass provider for [pi](https://github.com/earendil-works/pi) — 11 curated open-weight coding models (GLM-5.2, Kimi K2.7 Code, Kimi K3, DeepSeek V4, Qwen3.7, and more) through Cline's $9.99/month subscription with 2-5x standard API rate limits.
 
 ClinePass uses Cline's **OpenAI-compatible Chat Completions API**, so no custom streaming protocol is needed — pi's built-in `openai-completions` streaming handles SSE parsing, tool calls, and usage tracking.
 
@@ -58,6 +58,7 @@ pnpm add pi-clinepass-provider
 | GLM-5.2           | `cline-pass/glm-5.2`           | 200K    | off / low / medium / high / xhigh |
 | Kimi K2.7 Code    | `cline-pass/kimi-k2.7-code`    | 262K    | low / medium / high               |
 | Kimi K2.6         | `cline-pass/kimi-k2.6`         | 262K    | low / medium / high               |
+| Kimi K3           | `cline-pass/kimi-k3`           | 1M      | high (max; always on)              |
 | DeepSeek V4 Pro   | `cline-pass/deepseek-v4-pro`   | 1M      | off + high (high used for xhigh)  |
 | DeepSeek V4 Flash | `cline-pass/deepseek-v4-flash` | 1M      | off + high (high used for xhigh)  |
 | MiMo-V2.5         | `cline-pass/mimo-v2.5`         | 262K    | off / low / medium / high         |

--- a/src/models.ts
+++ b/src/models.ts
@@ -149,6 +149,24 @@ const MODELS_BASE: readonly ModelConfigBase[] = [
     },
   },
   {
+    id: "cline-pass/kimi-k3",
+    name: "Kimi K3 (ClinePass)",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 3.0, output: 15.0, cacheRead: 0.3, cacheWrite: 0 },
+    contextWindow: 1_048_576,
+    maxTokens: 131_072,
+    // K3 always reasons and currently only supports reasoning_effort="max".
+    thinkingLevelMap: {
+      off: null,
+      minimal: null,
+      low: null,
+      medium: null,
+      high: "max",
+      xhigh: null,
+    },
+  },
+  {
     id: "cline-pass/deepseek-v4-pro",
     name: "DeepSeek V4 Pro (ClinePass)",
     reasoning: true,

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -17,6 +17,7 @@ describe("modelIds", () => {
     expect(ids).toHaveLength(MODELS.length);
     expect(ids).toContain("cline-pass/glm-5.2");
     expect(ids).toContain("cline-pass/kimi-k2.7-code");
+    expect(ids).toContain("cline-pass/kimi-k3");
     expect(ids).toContain("cline-pass/deepseek-v4-flash");
   });
 
@@ -93,9 +94,9 @@ describe("MODELS", () => {
     }
   });
 
-  it("always-reasoning models (Kimi) mark off as null, support others like standard", () => {
-    const alwaysOn = ["cline-pass/kimi-k2.7-code", "cline-pass/kimi-k2.6"];
-    for (const id of alwaysOn) {
+  it("Kimi K2 models always reason but support standard efforts", () => {
+    const kimiK2Models = ["cline-pass/kimi-k2.7-code", "cline-pass/kimi-k2.6"];
+    for (const id of kimiK2Models) {
       const model = MODELS.find((m) => m.id === id)!;
       const map = model.thinkingLevelMap;
       expect(map.off).toBeNull();
@@ -105,6 +106,18 @@ describe("MODELS", () => {
       expect(map.medium).toBe("medium");
       expect(map.high).toBe("high");
     }
+  });
+
+  it("Kimi K3 always reasons with max effort only", () => {
+    const model = MODELS.find((m) => m.id === "cline-pass/kimi-k3")!;
+    expect(model.thinkingLevelMap).toEqual({
+      off: null,
+      minimal: null,
+      low: null,
+      medium: null,
+      high: "max",
+      xhigh: null,
+    });
   });
 
   it("DeepSeek V4 models only support high (and xhigh clamped to high)", () => {


### PR DESCRIPTION
## WHAT

 <!-- Links to task(s): -->
 - Add `Kimi K3` to the ClinePass static model catalog.

 <!-- Link to testing: -->
 - `npm test` (151 tests)
 - `npm run typecheck`
 - `npm run lint`
 - `npm run format:check`
 - Manual ClinePass validation: `clinepass/cline-pass/kimi-k3` with `--thinking high`

 <!-- Links to documentation or discussion -->
 - Updated `README.md`, `AGENTS.md`, `CONTEXT.md`, and codebase maps.

 ## WHY

 - Expose `cline-pass/kimi-k3` for pi users.
 - Provide its known context/output limits and reference pricing for model selection and usage tracking.

 ## HOW

 - Added `cline-pass/kimi-k3` to `src/models.ts`:
   - Context window: `1_048_576`
   - Max output: `131_072`
   - Cost: `$3.00/M` input, `$0.30/M` cache read, `$15.00/M` output
   - K3 always reasons; its only currently supported effort is `reasoning_effort: "max"`.
   - Maps pi `high` to `"max"`; all other thinking levels, including `off`, are `null`.
 - Added focused unit coverage for K3’s catalog ID and reasoning-level map.
 - Updated supported-model documentation from 10 to 11 models.

 ## Screenshots (if appropriate):

 Not applicable — no UI change.

 ## Types of changes

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

 ## Checklist:

 - [x] Linter
 - [x] Tests
 - [x] Review comments
 - [x] Security

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Kimi K3** (`cline-pass/kimi-k3`) to the supported ClinePass model catalog.
  * Includes a **1M-token context window** and **high/always-on max reasoning** behavior.

* **Documentation**
  * Updated the supported-models references and architecture docs to reflect the expanded **11-model** catalog (including Kimi K3).

* **Tests**
  * Added unit-test coverage to verify Kimi K3’s reasoning-level configuration and its supported/unsupported tiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->