### PR TITLE
feat(models): add Qwen3.8 Max to ClinePass catalog

### DIFF
--- a/.changeset/add-qwen3.8-max.md
+++ b/.changeset/add-qwen3.8-max.md
@@ -1,0 +1,12 @@
+---
+"pi-clinepass-provider": minor
+---
+
+feat: add Qwen3.8 Max to the ClinePass static model catalog
+
+Adds `cline-pass/qwen3.8-max` with its 1M context window, output limit, and
+reference pricing from Alibaba Cloud Model Studio (Singapore). Reasoning maps
+to qwen3.8-max's native `low`/`medium`/`xhigh` tiers; `minimal` and `high` are
+left unsupported (null) so no two offered thinking levels resolve to the same
+effort. `off` is also unsupported — the model only disables thinking via
+`enable_thinking: false`, which pi's openai-completions format does not send.

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -38,7 +38,7 @@
 **Models (`src/models.ts`):**
 
 - Purpose: Static `MODELS` catalog + dynamic discovery (`fetchRemoteModels`, `resolveModels`). Per-model `thinkingLevelMap` maps pi's 6 thinking levels to ClinePass `reasoning_effort`.
-- Location: `src/models.ts` (412 lines — largest module)
+- Location: `src/models.ts` (largest module)
 - Depends on: `env.ts`, `utils.ts`.
 
 **Auth (`src/auth.ts`):**

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -110,7 +110,7 @@
 **`ModelConfig` + `thinkingLevelMap`:**
 
 - Purpose: Declares a model's capabilities and the explicit mapping of pi's 6 thinking levels (`off|minimal|low|medium|high|xhigh`) to ClinePass `reasoning_effort` strings, or `null` (unsupported).
-- Examples: `src/models.ts` (11 static models + `DEFAULT_THINKING_LEVEL_MAP` / `NO_THINKING_MAP` for remote models).
+- Examples: `src/models.ts` (12 static models + `DEFAULT_THINKING_LEVEL_MAP` / `NO_THINKING_MAP` for remote models).
 - Pattern: Readonly `Record<ThinkingLevel, string|null>` — every model must declare all six levels (no implicit defaults). `off` maps to `"none"` for models that can disable reasoning; `null` for always-reasoning models (Kimi).
 
 **Injectable I/O options:**

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -13,7 +13,7 @@
 
 **`src/models.ts` exceeds the 300-line guideline:**
 
-- Issue: CONTRIBUTING.md states "Files should stay under 300 lines. If a module grows beyond that, extract a sub-module." `models.ts` is 466 lines — driven by the 11-entry static `MODELS` catalog (each with a 6-level `thinkingLevelMap`) plus the dynamic-discovery logic.
+- Issue: CONTRIBUTING.md states "Files should stay under 300 lines. If a module grows beyond that, extract a sub-module." `models.ts` is 487 lines — driven by the 12-entry static `MODELS` catalog (each with a 6-level `thinkingLevelMap`) plus the dynamic-discovery logic.
 - Files: `src/models.ts`
 - Impact: Mild — the catalog is repetitive data, not complex logic; locality is still good. But it sets a precedent for ignoring the guideline as more models are added.
 - Fix approach: Either (a) extract the static `MODELS` array into `src/models/static-catalog.ts` and keep `models.ts` for types + discovery, or (b) raise the guideline explicitly for data-table modules. Low priority; revisit when the catalog grows past ~15 models.
@@ -69,7 +69,7 @@ None significant. The extension is stateless after registration. Startup does on
 
 **Model catalog growth:**
 
-- Current capacity: 11 static models, 466-line `models.ts`.
+- Current capacity: 12 static models, 487-line `models.ts`.
 - Limit: No hard limit; each model adds ~25 lines. The 300-line guideline will be increasingly violated.
 - Scaling path: Extract static catalog to its own module (see Tech Debt above) or move to a data file (JSON/TS data table) parsed at load.
 

--- a/.planning/implement-notes.md
+++ b/.planning/implement-notes.md
@@ -67,3 +67,10 @@ _(append below — newest at bottom)_
 - **Type:** issue
 - **Detail:** `cline-pass/qwen3.7-max` and `cline-pass/qwen3.7-plus` both declare `off: "none"`. A manual check against the live API showed qwen3.7 still thinks with thinking set to off, i.e. the same out-of-enum `reasoning_effort` behaviour.
 - **Follow-up:** left unchanged deliberately — out of scope for the Qwen3.8 Max PR. Worth a separate fix setting `off: null` on both entries after confirming against the provider docs.
+
+### 2026-08-21 — Qwen3.8 Max PR review gaps
+
+- **Context:** reviewing PR #55 before merge
+- **Type:** issue
+- **Detail:** the landing page implied an unsupported `high` reasoning level, architecture docs retained a stale line count, and the model-specific test did not pin catalog metadata.
+- **Follow-up:** listed the supported levels explicitly, removed the volatile line count, and added exact pricing and token-limit assertions.

--- a/.planning/implement-notes.md
+++ b/.planning/implement-notes.md
@@ -53,3 +53,17 @@ _(append below — newest at bottom)_
 - **Type:** learning
 - **Detail:** GitHub's review-comment REST endpoint requires `in_reply_to` as a JSON number; `gh api -f` serializes it as a string and is rejected.
 - **Follow-up:** use `gh api --input` with a JSON payload for inline replies.
+
+### 2026-08-10 — qwen3.8-max cannot disable thinking via reasoning_effort
+
+- **Context:** pre-PR review of the `cline-pass/qwen3.8-max` catalog entry
+- **Type:** issue
+- **Detail:** `off: "none"` is a no-op. Intercepting the wire (point `CLINE_API_BASE` at a local HTTP server) shows pi sends `reasoning_effort: "none"` for `--thinking off`, but qwen3.8-max's enum is only `low`/`medium`/`xhigh` (default `xhigh`) and thinking is disabled solely via `enable_thinking: false`. pi's default `openai` thinkingFormat never sends that field, so the value is ignored and the model keeps thinking while the UI reports "off". Setting `compat.thinkingFormat: "qwen"` does send `enable_thinking`, but that branch in `openai-completions.js` is an exclusive `else if` that then omits `reasoning_effort` entirely, losing all tier control.
+- **Follow-up:** set `off: null` so the level is not offered, matching the Kimi K3 precedent. Confirmed by test: `getSupportedThinkingLevels` drops null levels, leaving `low`/`medium`/`xhigh`.
+
+### 2026-08-10 — same reasoning_effort no-op likely affects qwen3.7 entries
+
+- **Context:** follow-on from the qwen3.8-max finding above
+- **Type:** issue
+- **Detail:** `cline-pass/qwen3.7-max` and `cline-pass/qwen3.7-plus` both declare `off: "none"`. A manual check against the live API showed qwen3.7 still thinks with thinking set to off, i.e. the same out-of-enum `reasoning_effort` behaviour.
+- **Follow-up:** left unchanged deliberately — out of scope for the Qwen3.8 Max PR. Worth a separate fix setting `off: null` on both entries after confirming against the provider docs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ This file is the handoff trail between agents and humans. If you resolve an item
 - **`src/index.ts`** — Entry. Calls `pi.registerProvider()`, wires models + OAuth + error handler.
 - **`src/env.ts`** — Constants (`DEFAULT_API_BASE`, `ENV_API_KEY`, `PROVIDER_NAME`), `resolveApiBase()`, `sanitizeApiKey()`, `buildEndpointUrl()`.
 - **`src/auth.ts`** — API key resolution chain: env var → `~/.cline/data/settings/providers.json` → `~/.pi/agent/auth.json`. Shared `walkAuthPaths()` / `walkClineProviderSettings()` utilities used by both auth and workos modules.
-- **`src/models.ts`** — Static model definitions (11 curated models with pricing + thinking level maps) and dynamic model discovery (`fetchRemoteModels`, `resolveModels`). 5-second fetch timeout.
+- **`src/models.ts`** — Static model definitions (12 curated models with pricing + thinking level maps) and dynamic model discovery (`fetchRemoteModels`, `resolveModels`). 5-second fetch timeout.
 - **`src/workos.ts`** — WorkOS OAuth protocol adapter: credential extraction from providers.json and `~/.pi/agent/auth.json`, token refresh via Cline's `/api/v1/auth/refresh`, `isWorkosToken()` check.
 - **`src/oauth.ts`** — `/login` flow: auto-detects existing WorkOS credentials, falls back to browser-assisted manual API key paste. `refreshToken()` delegates to WorkOS refresh or returns static key unchanged.
 - **`src/error-handler.ts`** + **`src/errors.ts`** — `message_end` handler that classifies ClinePass 401/403/429 errors into user-friendly notifications.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,7 +53,7 @@ A JSON file that pi uses to persist OAuth credentials. Two formats exist:
 
 ### Static Model Catalog
 
-A hardcoded list of 11 curated models (GLM-5.2, Kimi K2.7 Code, Kimi K2.6, Kimi K3, DeepSeek V4 Pro, DeepSeek V4 Flash, MiMo-V2.5, MiMo-V2.5-Pro, MiniMax M3, Qwen3.7 Max, Qwen3.7 Plus) with reference pricing, context windows, and token limits.
+A hardcoded list of 12 curated models (GLM-5.2, Kimi K2.7 Code, Kimi K2.6, Kimi K3, DeepSeek V4 Pro, DeepSeek V4 Flash, MiMo-V2.5, MiMo-V2.5-Pro, MiniMax M3, Qwen3.7 Max, Qwen3.7 Plus, Qwen3.8 Max) with reference pricing, context windows, and token limits.
 
 ### Dynamic Model Discovery
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/jellydn/pi-clinepass-provider/workflows/CI/badge.svg)](https://github.com/jellydn/pi-clinepass-provider/actions)
 
-> ClinePass provider for [pi](https://github.com/earendil-works/pi) — 11 curated open-weight coding models (GLM-5.2, Kimi K2.7 Code, Kimi K3, DeepSeek V4, Qwen3.7, and more) through Cline's $9.99/month subscription with 2-5x standard API rate limits.
+> ClinePass provider for [pi](https://github.com/earendil-works/pi) — 12 curated open-weight coding models (GLM-5.2, Kimi K2.7 Code, Kimi K3, DeepSeek V4, Qwen3.8 Max, and more) through Cline's $9.99/month subscription with 2-5x standard API rate limits.
 
 ClinePass uses Cline's **OpenAI-compatible Chat Completions API**, so no custom streaming protocol is needed — pi's built-in `openai-completions` streaming handles SSE parsing, tool calls, and usage tracking.
 
@@ -66,6 +66,7 @@ pnpm add pi-clinepass-provider
 | MiniMax M3        | `cline-pass/minimax-m3`        | 1M      | off / low / medium / high         |
 | Qwen3.7 Max       | `cline-pass/qwen3.7-max`       | 262K    | off / low / medium / high         |
 | Qwen3.7 Plus      | `cline-pass/qwen3.7-plus`      | 1M      | off / low / medium / high         |
+| Qwen3.8 Max       | `cline-pass/qwen3.8-max`       | 1M      | low / medium / xhigh              |
 
 > **Thinking levels**: pi supports 6 levels — `off`, `minimal`, `low`, `medium`, `high`, `xhigh`. Each model declares which levels it supports, mapped to the provider's `reasoning_effort` parameter. Set the thinking level with pi's `--thinking` flag or `/thinking` command. A level marked as unsupported (not listed above) maps to `null` — no `reasoning_effort` is sent to the API, so the model runs with its default reasoning behavior.
 

--- a/site/index.html
+++ b/site/index.html
@@ -353,7 +353,7 @@
             <td><span class="tag tag-ctx">1M</span></td>
             <td class="cost">$2.00<span class="cost-label">/M tok</span></td>
             <td class="cost">$6.00<span class="cost-label">/M tok</span></td>
-            <td><span class="tag tag-think">low → xhigh</span></td>
+            <td><span class="tag tag-think">low / medium / xhigh</span></td>
           </tr>
         </tbody>
       </table>

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>pi-clinepass-provider — ClinePass for pi</title>
-<meta name="description" content="11 curated open-weight coding models through Cline's $9.99/month subscription, directly in pi">
+<meta name="description" content="12 curated open-weight coding models through Cline's $9.99/month subscription, directly in pi">
 <meta name="color-scheme" content="dark">
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -207,7 +207,7 @@
 
 <section class="hero">
   <div class="wrap">
-    <h1>Access <em>11 open-weight</em><br>coding models in pi</h1>
+    <h1>Access <em>12 open-weight</em><br>coding models in pi</h1>
     <p>Use GLM-5.2, Kimi K2.7, DeepSeek V4, Qwen3.7, and more through your ClinePass subscription — directly inside pi with full streaming, tool calls, and thinking level support.</p>
     <div class="install-block">
       <code>pi install npm:pi-clinepass-provider</code>
@@ -221,7 +221,7 @@
   <div class="wrap">
     <div class="section-head">
       <h2>Model catalog</h2>
-      <p>11 curated models with per-model thinking level support</p>
+      <p>12 curated models with per-model thinking level support</p>
     </div>
     <div class="table-wrap">
       <table>
@@ -345,6 +345,16 @@
             <td class="cost">$1.60<span class="cost-label">/M tok</span></td>
             <td><span class="tag tag-think">off → high</span></td>
           </tr>
+          <tr>
+            <td>
+              <span class="model-name">Qwen3.8 Max</span>
+              <span class="model-id">cline-pass/qwen3.8-max</span>
+            </td>
+            <td><span class="tag tag-ctx">1M</span></td>
+            <td class="cost">$2.00<span class="cost-label">/M tok</span></td>
+            <td class="cost">$6.00<span class="cost-label">/M tok</span></td>
+            <td><span class="tag tag-think">low → xhigh</span></td>
+          </tr>
         </tbody>
       </table>
     </div>
@@ -414,7 +424,7 @@
 
 <section class="cta">
   <div class="wrap">
-    <h2>One command, 11 models.</h2>
+    <h2>One command, 12 models.</h2>
     <p>Install and start using open-weight models in pi today.</p>
     <a href="https://github.com/jellydn/pi-clinepass-provider" class="btn">View on GitHub</a>
   </div>

--- a/src/models.ts
+++ b/src/models.ts
@@ -286,6 +286,28 @@ const MODELS_BASE: readonly ModelConfigBase[] = [
       xhigh: null,
     },
   },
+  {
+    id: "cline-pass/qwen3.8-max",
+    name: "Qwen3.8 Max (ClinePass)",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 2, output: 6, cacheRead: 0.25, cacheWrite: 2.5 },
+    contextWindow: 1_000_000,
+    maxTokens: 131_072,
+    // qwen3.8-max's reasoning_effort enum is low/medium/xhigh (default xhigh).
+    // Thinking can only be disabled via `enable_thinking: false`, which pi's
+    // openai-completions path never sends — reasoning_effort="none" is out of
+    // enum and silently ignored, leaving thinking on. "off" is therefore
+    // unsupported (null) rather than offered as a no-op, same as Kimi K3.
+    thinkingLevelMap: {
+      off: null,
+      minimal: null,
+      low: "low",
+      medium: "medium",
+      high: null,
+      xhigh: "xhigh",
+    },
+  },
 ];
 
 export const MODELS: readonly ModelConfig[] = MODELS_BASE.map((model) => ({

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -94,6 +94,28 @@ describe("MODELS", () => {
     }
   });
 
+  it("Qwen3.8 Max offers low/medium/xhigh only", () => {
+    // qwen3.8-max exposes three native reasoning_effort tiers — low, medium,
+    // xhigh (its default) — and no tier between medium and xhigh. "high" is
+    // therefore left unsupported (null) rather than aliased to xhigh, so every
+    // offered thinking level produces a distinct result; "minimal" is null for
+    // the same reason (no tier below low).
+    //
+    // "off" is null because thinking cannot be disabled through this path:
+    // the model only honours `enable_thinking: false`, which pi's
+    // openai-completions format never sends, so reasoning_effort="none" is
+    // ignored and the model keeps thinking. Offering "off" would be a no-op
+    // that misreports the model's state (same reasoning as Kimi K3).
+    const model = MODELS.find((m) => m.id === "cline-pass/qwen3.8-max")!;
+    const map = model.thinkingLevelMap;
+    expect(map.off).toBeNull();
+    expect(map.minimal).toBeNull();
+    expect(map.low).toBe("low");
+    expect(map.medium).toBe("medium");
+    expect(map.high).toBeNull();
+    expect(map.xhigh).toBe("xhigh");
+  });
+
   it("Kimi K2 models always reason but support standard efforts", () => {
     const kimiK2Models = ["cline-pass/kimi-k2.7-code", "cline-pass/kimi-k2.6"];
     for (const id of kimiK2Models) {

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -114,6 +114,14 @@ describe("MODELS", () => {
     expect(map.medium).toBe("medium");
     expect(map.high).toBeNull();
     expect(map.xhigh).toBe("xhigh");
+    expect(model.cost).toEqual({
+      input: 2,
+      output: 6,
+      cacheRead: 0.25,
+      cacheWrite: 2.5,
+    });
+    expect(model.contextWindow).toBe(1_000_000);
+    expect(model.maxTokens).toBe(131_072);
   });
 
   it("Kimi K2 models always reason but support standard efforts", () => {


### PR DESCRIPTION
Now available on ClinePass [1]. Adds cline-pass/qwen3.8-max with pricing, context, and reasoning configuration sourced from the official docs.

Pricing + context Alibaba Cloud Model Studio, Singapore (International scope) [2], per 1M tokens:
- input $2.00, output $6.00
- cacheRead $0.25 (implicit cache hit)
- cacheWrite $2.50 (explicit cache creation, 125% of input)
- contextWindow 1,000,000; maxTokens 131,072 (max output length)

Reasoning; QwenCloud OpenAI-compatible chat API, reasoning_effort [3]: qwen3.8-max exposes three native tiers (low, medium, xhigh; default xhigh). The thinkingLevelMap offers exactly those and marks every other pi level unsupported:
  off -> null, minimal -> null, low -> low,
  medium -> medium, high -> null, xhigh -> xhigh

"off" is null because thinking cannot be disabled on this path: the model only honours enable_thinking=false, which pi's openai-completions format never sends, so reasoning_effort="none" falls outside the enum, is ignored, and the model keeps thinking while the UI reports "off" (confirmed against the live API). Same treatment as Kimi K3. "minimal" and "high" are null because the model has no tier below low or between medium and xhigh, so pi drops them from the cycle rather than aliasing two levels to one effort.

Also adds a changeset (minor), updates the landing page and README model tables, the model count (11 -> 12), and records the reasoning_effort finding in .planning/implement-notes.md.

[1] https://x.com/cline/status/2084689818999718309
[2] https://www.alibabacloud.com/help/en/model-studio/qwen3-8-max
[3] https://docs.qwencloud.com/api-reference/chat/openai-chat


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Qwen3.8 Max to the supported model catalog.
  * Included its model ID, pricing, 1,000,000-token context window, 131,072-token output limit, and supported reasoning levels.
  * Expanded the catalog to 12 curated models.
  * Updated the landing page and README with Qwen3.8 Max details.

* **Documentation**
  * Updated architecture and implementation notes to reflect the expanded catalog and Qwen reasoning behavior.

* **Tests**
  * Added coverage for Qwen3.8 Max metadata and supported reasoning levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->