### PR TITLE
feat(models): add GLM-5.3 to ClinePass catalog

### DIFF
--- a/.changeset/add-glm-5.3.md
+++ b/.changeset/add-glm-5.3.md
@@ -1,0 +1,11 @@
+---
+"pi-clinepass-provider": minor
+---
+
+feat: add GLM-5.3 to the ClinePass static model catalog
+
+Adds `cline-pass/glm-5.3` (Z.ai) with 1M context / 128K output. GLM-5.3 always
+reasons and cannot be disabled; its `reasoning_effort` enum is `low`/`high`/`max`
+(default `max`) with no `medium` or `xhigh` tier. pi's `off`/`minimal`/`medium`
+map to `null` and `xhigh` maps to `max` so every offered level is distinct and
+increasing. Pricing mirrors GLM-5.2 per the ClinePass docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **GLM-5.3 model** — registered `cline-pass/glm-5.3` (Z.ai) in the static catalog with 1M context / 128K output. GLM-5.3 always reasons and cannot be disabled; its `reasoning_effort` enum is `low`/`high`/`max` (default `max`) with no `medium` or `xhigh` tier, so pi's `off`/`minimal`/`medium` map to `null` and `xhigh` maps to `max` (every offered level distinct and increasing). Pricing mirrors GLM-5.2 per the ClinePass docs ($1.40/$4.40/$0.26).
+
 ### Docs
 
 - **Thinking levels usage guide** — added Reasoning column to Supported Models table showing per-model thinking level capabilities (off/minimal/low/medium/high/xhigh), plus `--thinking` flag examples in Usage section ([#17](https://github.com/jellydn/pi-clinepass-provider/issues/17))

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pnpm add pi-clinepass-provider
 
 | Model             | Model ID                       | Context | Reasoning                         |
 | :---------------- | :----------------------------- | :------ | :-------------------------------- |
-| GLM-5.3           | `cline-pass/glm-5.3`           | 1M      | low / high / max (always on)      |
+| GLM-5.3           | `cline-pass/glm-5.3`           | 1M      | low / high / xhigh (xhigh → max; always on) |
 | GLM-5.2           | `cline-pass/glm-5.2`           | 200K    | off / low / medium / high / xhigh |
 | Kimi K2.7 Code    | `cline-pass/kimi-k2.7-code`    | 262K    | low / medium / high               |
 | Kimi K2.6         | `cline-pass/kimi-k2.6`         | 262K    | low / medium / high               |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/jellydn/pi-clinepass-provider/workflows/CI/badge.svg)](https://github.com/jellydn/pi-clinepass-provider/actions)
 
-> ClinePass provider for [pi](https://github.com/earendil-works/pi) — 12 curated open-weight coding models (GLM-5.2, Kimi K2.7 Code, Kimi K3, DeepSeek V4, Qwen3.8 Max, and more) through Cline's $9.99/month subscription with 2-5x standard API rate limits.
+> ClinePass provider for [pi](https://github.com/earendil-works/pi) — 13 curated open-weight coding models (GLM-5.3, GLM-5.2, Kimi K2.7 Code, Kimi K3, DeepSeek V4, Qwen3.8 Max, and more) through Cline's $9.99/month subscription with 2-5x standard API rate limits.
 
 ClinePass uses Cline's **OpenAI-compatible Chat Completions API**, so no custom streaming protocol is needed — pi's built-in `openai-completions` streaming handles SSE parsing, tool calls, and usage tracking.
 
@@ -55,6 +55,7 @@ pnpm add pi-clinepass-provider
 
 | Model             | Model ID                       | Context | Reasoning                         |
 | :---------------- | :----------------------------- | :------ | :-------------------------------- |
+| GLM-5.3           | `cline-pass/glm-5.3`           | 1M      | low / high / max (always on)      |
 | GLM-5.2           | `cline-pass/glm-5.2`           | 200K    | off / low / medium / high / xhigh |
 | Kimi K2.7 Code    | `cline-pass/kimi-k2.7-code`    | 262K    | low / medium / high               |
 | Kimi K2.6         | `cline-pass/kimi-k2.6`         | 262K    | low / medium / high               |
@@ -139,6 +140,9 @@ pi --model clinepass/cline-pass/deepseek-v4-pro --thinking high -p "Design a sca
 
 # GLM-5.2 supports five levels up to xhigh
 pi --model clinepass/cline-pass/glm-5.2 --thinking xhigh -p "Solve this complex math proof"
+
+# GLM-5.3 always reasons; pick low/high/max effort (xhigh → max)
+pi --model clinepass/cline-pass/glm-5.3 --thinking xhigh -p "Refactor this monolith into services"
 
 # Disable reasoning for a quick code gen task
 pi --model clinepass/cline-pass/deepseek-v4-flash --thinking off -p "Write a React form component"

--- a/src/models.ts
+++ b/src/models.ts
@@ -98,6 +98,31 @@ interface ModelConfigBase extends Omit<ModelConfig, "compat"> {
 
 const MODELS_BASE: readonly ModelConfigBase[] = [
   {
+    id: "cline-pass/glm-5.3",
+    name: "GLM-5.3 (ClinePass)",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 },
+    contextWindow: 1_048_576,
+    maxTokens: 131_072,
+    // GLM-5.3 (Z.ai) always reasons and cannot be disabled — its
+    // reasoning_effort enum is low/high/max (default max), with no "medium"
+    // or "xhigh" tier. "off"/"minimal" are null because thinking can't be
+    // turned off and there is no tier below low; "medium" is null for the
+    // same enum-gap reason. pi's "xhigh" maps to "max", the extra-high
+    // tier, so every offered level (low/high/xhigh) is distinct and
+    // increasing — mirroring Kimi K3's use of "max" and Qwen3.8-max's
+    // sparse-level pattern.
+    thinkingLevelMap: {
+      off: null,
+      minimal: null,
+      low: "low",
+      medium: null,
+      high: "high",
+      xhigh: "max",
+    },
+  },
+  {
     id: "cline-pass/glm-5.2",
     name: "GLM-5.2 (ClinePass)",
     reasoning: true,

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -15,6 +15,7 @@ describe("modelIds", () => {
   it("returns all model IDs", () => {
     const ids = modelIds();
     expect(ids).toHaveLength(MODELS.length);
+    expect(ids).toContain("cline-pass/glm-5.3");
     expect(ids).toContain("cline-pass/glm-5.2");
     expect(ids).toContain("cline-pass/kimi-k2.7-code");
     expect(ids).toContain("cline-pass/kimi-k3");
@@ -172,6 +173,32 @@ describe("MODELS", () => {
     expect(map.medium).toBe("medium");
     expect(map.high).toBe("high");
     expect(map.xhigh).toBe("xhigh");
+  });
+
+  it("GLM-5.3 supports low/high/max only (thinking always on)", () => {
+    // GLM-5.3 (Z.ai) always reasons and cannot be disabled; its
+    // reasoning_effort enum is low/high/max (default max) with no "medium"
+    // or "xhigh" tier. "off"/"minimal"/"medium" are null (no corresponding
+    // tier, and thinking can't be turned off); pi's "xhigh" maps to "max",
+    // the extra-high tier, so every offered level is distinct and
+    // increasing. Pricing/context mirror GLM-5.2 per the ClinePass docs.
+    const model = MODELS.find((m) => m.id === "cline-pass/glm-5.3")!;
+    const map = model.thinkingLevelMap;
+    expect(map.off).toBeNull();
+    expect(map.minimal).toBeNull();
+    expect(map.low).toBe("low");
+    expect(map.medium).toBeNull();
+    expect(map.high).toBe("high");
+    expect(map.xhigh).toBe("max");
+    expect(model.cost).toEqual({
+      input: 1.4,
+      output: 4.4,
+      cacheRead: 0.26,
+      cacheWrite: 0,
+    });
+    expect(model.contextWindow).toBe(1_048_576);
+    expect(model.maxTokens).toBe(131_072);
+    expect(model.reasoning).toBe(true);
   });
 
   it("maps pi off to none for GLM-5.2 (issue #17)", () => {


### PR DESCRIPTION
## What

Adds `cline-pass/glm-5.3` to the static model catalog. GLM-5.3 is listed in the
[ClinePass docs](https://docs.cline.bot/getting-started/clinepass) but missing here, so it
only appears when dynamic discovery succeeds (the `/models` endpoint currently 404s).

| | |
|---|---|
| Context / output | 1M / 128K |
| Pricing (ref) | $1.40 in / $4.40 out / $0.26 cached — same as GLM-5.2 |

## Why the thinking map differs from GLM-5.2

GLM-5.3 [always reasons](https://docs.z.ai/guides/llm/glm-5.3) and its `reasoning_effort`
enum is `low` / `high` / `max` only — no `medium`, no `xhigh`, and no way to disable
thinking. So instead of copying GLM-5.2's map:

- `off` / `minimal` / `medium` → `null` (no corresponding tier; thinking can't be turned off)
- `low` → `low`, `high` → `high`
- `xhigh` → `max` (the extra-high tier)

This mirrors the existing patterns for Kimi K3 (`max`) and Qwen3.8-max (sparse levels).

## Verification

- `vitest`: 169/169 passing (includes a new GLM-5.3 unit test)
- `tsc` and `oxlint` clean

---

**Note:** Tested in my Pi setup (extension loads and the model registers/works via ClinePass). This PR was built with GLM-5.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the GLM-5.3 model in the ClinePass catalog.
  - GLM-5.3 uses always-on reasoning with low, high, and max effort levels; `xhigh` maps to max.
  - Added model details, including pricing, context window, and output token limits.
  - Added usage guidance and documentation for selecting reasoning effort.
  - Added validation coverage for the model’s configuration and reasoning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->